### PR TITLE
proxy: self-healing credential auth (directory mounts + failure classification + auth snapshot)

### DIFF
--- a/deploy/docker/compose.scillm.core.yml
+++ b/deploy/docker/compose.scillm.core.yml
@@ -34,15 +34,20 @@ services:
       utls-proxy:
         condition: service_healthy
     volumes:
-      - "../../local/proxy_server_config.yaml:/app/config.yaml:ro"
-      - "${HOME}/.pi/agent/auth.json:/root/.pi/agent/auth.json:ro"
-      - "${HOME}/.claude/.credentials.json:/root/.claude/.credentials.json:ro"
-      - "${HOME}/.codex/auth.json:/root/.codex/auth.json:ro"
+      # Keep deploy-time config on the durable checkout, not the invoking
+      # worktree (which may live under /tmp and disappear before a restart).
+      - "${SCILLM_REPO_ROOT:-/home/graham/workspace/experiments/scillm}/local/proxy_server_config.yaml:/app/config.yaml:ro"
+      # Credential CLIs rotate files with atomic rename. Mount their parent
+      # directories read-write so the container follows the replacement inode
+      # and scillm can write refreshed tokens back to the host.
+      - "${HOME}/.pi/agent:/root/.pi/agent"
+      - "${HOME}/.claude:/root/.claude"
+      - "${HOME}/.codex:/root/.codex"
       # Gemini CLI needs write access for history/sessions
       - "${HOME}/.gemini:/root/.gemini"
       # OpenCode Go model discovery needs the connected provider auth/config.
       # Cache is writable so `opencode models --refresh opencode-go` can update.
-      - "${HOME}/.local/share/opencode/auth.json:/root/.local/share/opencode/auth.json:ro"
+      - "${HOME}/.local/share/opencode:/root/.local/share/opencode"
       - "${HOME}/.config/opencode:/root/.config/opencode:ro"
       - "${HOME}/.cache/opencode:/root/.cache/opencode"
       # JSONL backup — independent of DB, survives wipes, append-only

--- a/src/scillm/proxy/app.py
+++ b/src/scillm/proxy/app.py
@@ -2167,68 +2167,9 @@ async def scillm_auth(request: Request):
     if auth_err:
         raise ProxyError(401, auth_err, "authentication_error")
 
-    import time
-    from scillm.proxy.providers.auth import (
-        _read_claude_code_credentials,
-        _read_codex_auth,
-        _read_auth,
-        CLAUDE_CODE_CREDENTIALS,
-        CODEX_AUTH_FILE,
-        AUTH_FILE,
-    )
+    from scillm.proxy.providers.auth import get_auth_status_snapshot
 
-    now_ms = int(time.time() * 1000)
-    result: dict = {"timestamp": now_ms}
-
-    # Claude
-    cc = _read_claude_code_credentials()
-    if cc:
-        expires = cc.get("expiresAt", 0)
-        remaining_s = max(0, (expires - now_ms) // 1000)
-        result["claude"] = {
-            "status": "valid" if now_ms < expires else "expired",
-            "source": str(CLAUDE_CODE_CREDENTIALS),
-            "expires_in_s": remaining_s,
-            "subscription": cc.get("subscriptionType", "unknown"),
-            "rate_tier": cc.get("rateLimitTier", "unknown"),
-        }
-    else:
-        # Check Pi fallback
-        pi_data = _read_auth()
-        pi_cred = pi_data.get("anthropic", {})
-        if pi_cred.get("type") == "oauth":
-            expires = pi_cred.get("expires", 0)
-            remaining_s = max(0, (expires - now_ms) // 1000)
-            result["claude"] = {
-                "status": "valid" if now_ms < expires else "expired",
-                "source": str(AUTH_FILE),
-                "expires_in_s": remaining_s,
-            }
-        else:
-            result["claude"] = {"status": "not_configured"}
-
-    # Codex
-    codex = _read_codex_auth()
-    if codex:
-        result["codex"] = {
-            "status": "configured",
-            "source": str(CODEX_AUTH_FILE),
-            "account_id": (codex.get("account_id") or "")[:12] + "...",
-        }
-    else:
-        pi_data = _read_auth() if "pi_data" not in dir() else pi_data
-        pi_codex = pi_data.get("openai-codex", {})
-        if pi_codex.get("type") == "oauth":
-            expires = pi_codex.get("expires", 0)
-            result["codex"] = {
-                "status": "valid" if now_ms < expires else "expired",
-                "source": str(AUTH_FILE),
-                "expires_in_s": max(0, (expires - now_ms) // 1000),
-            }
-        else:
-            result["codex"] = {"status": "not_configured"}
-
-    return result
+    return get_auth_status_snapshot()
 
 
 @app.get("/v1/scillm/auth")

--- a/src/scillm/proxy/providers/auth.py
+++ b/src/scillm/proxy/providers/auth.py
@@ -7,16 +7,30 @@ Auto-refreshes expired tokens using the provider's refresh endpoint.
 from __future__ import annotations
 
 import json
+import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import httpx
 from loguru import logger
 
-AUTH_FILE = Path.home() / ".pi" / "agent" / "auth.json"
-CLAUDE_CODE_CREDENTIALS = Path.home() / ".claude" / ".credentials.json"
-CODEX_AUTH_FILE = Path.home() / ".codex" / "auth.json"
+# These directories are bind-mounted as directories in compose. Keeping the
+# file constants derived from their parent directories makes the atomic-rename
+# requirement explicit while preserving the standard CLI paths.
+PI_AUTH_DIR = Path.home() / ".pi" / "agent"
+CLAUDE_CODE_AUTH_DIR = Path.home() / ".claude"
+CODEX_AUTH_DIR = Path.home() / ".codex"
+OPENCODE_AUTH_DIR = Path.home() / ".local" / "share" / "opencode"
+
+AUTH_FILE = PI_AUTH_DIR / "auth.json"
+CLAUDE_CODE_CREDENTIALS = CLAUDE_CODE_AUTH_DIR / ".credentials.json"
+CODEX_AUTH_FILE = CODEX_AUTH_DIR / "auth.json"
+OPENCODE_AUTH_FILE = OPENCODE_AUTH_DIR / "auth.json"
+
+AUTH_STALE_FILE_THRESHOLD_S = float(os.environ.get("SCILLM_AUTH_STALE_FILE_THRESHOLD_S", "21600"))
+_LAST_REFRESH_OUTCOMES: dict[str, dict[str, Any]] = {}
 
 # Anthropic OAuth
 ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -26,6 +40,220 @@ ANTHROPIC_EXPIRY_BUFFER_MS = 5 * 60 * 1000  # 5-minute safety margin
 # OpenAI Codex OAuth
 CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+
+
+@dataclass(frozen=True)
+class _RefreshFailure:
+    reason: str
+    context: str
+    http_status: int | None = None
+    provider_error_code: str | None = None
+    provider_error_body_classification: str = "ambiguous_error"
+
+    @property
+    def requires_human_login(self) -> bool:
+        return self.provider_error_body_classification.startswith("login_required_")
+
+
+def _http_failure(exc: httpx.HTTPStatusError) -> _RefreshFailure:
+    """Preserve provider error context without exposing an unbounded body."""
+    response = exc.response
+    status = response.status_code
+    provider_error_code: str | None = None
+    provider_message: str | None = None
+
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, ValueError):
+        payload = None
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            provider_error_code = error.get("code") or error.get("type")
+            provider_message = error.get("message")
+        elif isinstance(error, str):
+            provider_error_code = error
+        provider_error_code = provider_error_code or payload.get("code")
+        provider_message = (
+            provider_message
+            or payload.get("error_description")
+            or payload.get("message")
+        )
+
+    body_text = response.text[:500]
+    classification_text = " ".join(
+        part
+        for part in (
+            provider_error_code,
+            provider_message,
+            body_text,
+        )
+        if isinstance(part, str)
+    ).lower()
+
+    if "invalid_grant" in classification_text:
+        body_classification = "login_required_invalid_grant"
+    elif "revoked" in classification_text:
+        body_classification = "login_required_revoked"
+    elif any(
+        marker in classification_text
+        for marker in (
+            "expired session",
+            "session expired",
+            "invalid refresh token",
+            "refresh token is invalid",
+            "refresh token has expired",
+            "expired refresh token",
+        )
+    ):
+        body_classification = "login_required_expired_or_invalid_session"
+    elif status in {401, 403} and any(
+        marker in classification_text
+        for marker in (
+            "auth",
+            "unauthorized",
+            "forbidden",
+            "token",
+            "credential",
+            "login",
+            "session",
+        )
+    ):
+        body_classification = "login_required_http_auth_error"
+    elif status >= 500:
+        body_classification = "ambiguous_server_error"
+    else:
+        body_classification = "ambiguous_http_error"
+
+    context = provider_message or provider_error_code or str(exc)
+    return _RefreshFailure(
+        reason="http_error",
+        context=str(context)[:500],
+        http_status=status,
+        provider_error_code=provider_error_code,
+        provider_error_body_classification=body_classification,
+    )
+
+
+def _refresh_exception_failure(exc: Exception) -> _RefreshFailure:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return _http_failure(exc)
+    if isinstance(exc, httpx.RequestError):
+        return _RefreshFailure(
+            reason="network_error",
+            context=str(exc)[:500],
+            provider_error_body_classification="ambiguous_network_error",
+        )
+    return _RefreshFailure(
+        reason="refresh_error",
+        context=f"{type(exc).__name__}: {exc}"[:500],
+        provider_error_body_classification="ambiguous_refresh_error",
+    )
+
+
+def _credential_file_mtime_ms(path: Path) -> int | None:
+    """Return the credential mtime visible to this process/container."""
+    try:
+        return int(path.stat().st_mtime * 1000)
+    except OSError:
+        return None
+
+
+def _jwt_expiry_ms(access_token: str) -> int | None:
+    """Extract an expiry from a JWT without treating unverified data as auth."""
+    import base64
+
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        expires_s = payload.get("exp")
+        return int(expires_s * 1000) if expires_s is not None else None
+    except Exception:
+        return None
+
+
+def _refresh_failure_details(
+    provider: str,
+    credential_file: Path,
+    failure: _RefreshFailure | None,
+) -> dict[str, Any]:
+    """Classify a failed refresh, prioritizing definitive provider auth errors."""
+    now_ms = int(time.time() * 1000)
+    mtime_ms = _credential_file_mtime_ms(credential_file)
+    age_s = max(0.0, (now_ms - mtime_ms) / 1000) if mtime_ms is not None else None
+    stale = age_s is not None and age_s >= AUTH_STALE_FILE_THRESHOLD_S
+    login_required = failure is not None and failure.requires_human_login
+
+    if login_required:
+        status = "needs_human_login"
+        message = (
+            f"{provider} OAuth refresh was rejected by the provider "
+            f"({failure.provider_error_body_classification}). Run the provider CLI login on the "
+            "host, then retry."
+        )
+    elif stale:
+        status = "stale_bind_mount_suspected"
+        message = (
+            f"{provider} OAuth refresh failed and {credential_file} is {int(age_s)}s old in the "
+            "container. Recreate/redeploy the scillm-proxy so its directory credential bind mount "
+            "is applied, then retry. If refresh still fails with a current mtime, run the provider "
+            "CLI login; do not assume login is required before remounting."
+        )
+    else:
+        status = "needs_human_login"
+        message = (
+            f"{provider} OAuth refresh failed with a current or unavailable credential-file mtime. "
+            "Run the provider CLI login on the host, then retry."
+        )
+
+    return {
+        "outcome": "failed",
+        "attempted_at_ms": now_ms,
+        "credential_file": str(credential_file),
+        "credential_file_mtime_ms": mtime_ms,
+        "provider_auth_status": status,
+        "project_agent_message": message,
+        "failure_reason": failure.reason if failure is not None else "unknown_refresh_failure",
+        "failure_context": failure.context if failure is not None else None,
+        "http_status": failure.http_status if failure is not None else None,
+        "provider_error_code": failure.provider_error_code if failure is not None else None,
+        "provider_error_body_classification": (
+            failure.provider_error_body_classification if failure is not None else "ambiguous_error"
+        ),
+    }
+
+
+def _record_refresh_failure(
+    provider: str,
+    credential_file: Path,
+    failure: _RefreshFailure | None,
+) -> None:
+    details = _refresh_failure_details(provider, credential_file, failure)
+    _LAST_REFRESH_OUTCOMES[provider] = details
+    logger.bind(provider=provider, **details).error("OAuth credential refresh failed")
+
+
+def _record_refresh_success(provider: str, credential_file: Path) -> None:
+    _LAST_REFRESH_OUTCOMES[provider] = {
+        "outcome": "succeeded",
+        "attempted_at_ms": int(time.time() * 1000),
+        "credential_file": str(credential_file),
+        "credential_file_mtime_ms": _credential_file_mtime_ms(credential_file),
+        "provider_auth_status": "valid",
+        "project_agent_message": None,
+    }
+
+
+def _missing_refresh_token_failure() -> _RefreshFailure:
+    return _RefreshFailure(
+        reason="missing_refresh_token",
+        context="OAuth credential has no refresh token",
+        provider_error_body_classification="ambiguous_missing_refresh_token",
+    )
 
 
 def _read_auth() -> dict[str, Any]:
@@ -47,8 +275,8 @@ def _write_auth(data: dict[str, Any]) -> None:
         logger.warning("Failed to write auth.json: {}", exc)
 
 
-def _refresh_anthropic(cred: dict[str, Any]) -> dict[str, Any] | None:
-    """Refresh Anthropic OAuth token. Returns updated credential or None."""
+def _refresh_anthropic(cred: dict[str, Any]) -> dict[str, Any] | _RefreshFailure:
+    """Refresh Anthropic OAuth token, preserving structured failure context."""
     try:
         resp = httpx.post(
             ANTHROPIC_TOKEN_URL,
@@ -71,12 +299,13 @@ def _refresh_anthropic(cred: dict[str, Any]) -> dict[str, Any] | None:
         logger.info("Refreshed Anthropic OAuth token (expires in {}s)", expires_in)
         return new_cred
     except Exception as exc:
-        logger.error("Anthropic token refresh failed: {}", exc)
-        return None
+        failure = _refresh_exception_failure(exc)
+        logger.error("Anthropic token refresh failed: {}", failure)
+        return failure
 
 
-def _refresh_codex(cred: dict[str, Any]) -> dict[str, Any] | None:
-    """Refresh OpenAI Codex OAuth token. Returns updated credential or None."""
+def _refresh_codex(cred: dict[str, Any]) -> dict[str, Any] | _RefreshFailure:
+    """Refresh OpenAI Codex OAuth token, preserving structured failure context."""
     try:
         resp = httpx.post(
             CODEX_TOKEN_URL,
@@ -106,8 +335,9 @@ def _refresh_codex(cred: dict[str, Any]) -> dict[str, Any] | None:
         logger.info("Refreshed Codex OAuth token (expires in {}s)", expires_in)
         return new_cred
     except Exception as exc:
-        logger.error("Codex token refresh failed: {}", exc)
-        return None
+        failure = _refresh_exception_failure(exc)
+        logger.error("Codex token refresh failed: {}", failure)
+        return failure
 
 
 def _extract_codex_account_id(access_token: str) -> str | None:
@@ -155,25 +385,35 @@ def get_anthropic_token() -> str | None:
         if now_ms < expires:
             logger.debug("Using Claude Code OAuth token (expires in {}s)", (expires - now_ms) // 1000)
             return cc_creds["accessToken"]
-        # Claude Code token expired — try to refresh it
-        logger.info("Claude Code token expired, refreshing...")
-        new_cred = _refresh_anthropic({
-            "refresh": cc_creds["refreshToken"],
-            "access": cc_creds["accessToken"],
-            "expires": expires,
-        })
-        if new_cred:
-            # Write back to Claude Code credentials format
-            try:
-                data = json.loads(CLAUDE_CODE_CREDENTIALS.read_text())
-                data["claudeAiOauth"]["accessToken"] = new_cred["access"]
-                data["claudeAiOauth"]["refreshToken"] = new_cred["refresh"]
-                data["claudeAiOauth"]["expiresAt"] = new_cred["expires"]
-                CLAUDE_CODE_CREDENTIALS.write_text(json.dumps(data, indent=2))
-                logger.info("Updated Claude Code credentials after refresh")
-            except OSError as exc:
-                logger.warning("Could not update Claude Code credentials: {}", exc)
-            return new_cred["access"]
+        refresh_token = cc_creds.get("refreshToken")
+        if not refresh_token:
+            _record_refresh_failure(
+                "claude",
+                CLAUDE_CODE_CREDENTIALS,
+                _missing_refresh_token_failure(),
+            )
+        else:
+            # Claude Code token expired — try to refresh it
+            logger.info("Claude Code token expired, refreshing...")
+            new_cred = _refresh_anthropic({
+                "refresh": refresh_token,
+                "access": cc_creds["accessToken"],
+                "expires": expires,
+            })
+            if isinstance(new_cred, dict):
+                # Write back to Claude Code credentials format
+                try:
+                    data = json.loads(CLAUDE_CODE_CREDENTIALS.read_text())
+                    data["claudeAiOauth"]["accessToken"] = new_cred["access"]
+                    data["claudeAiOauth"]["refreshToken"] = new_cred["refresh"]
+                    data["claudeAiOauth"]["expiresAt"] = new_cred["expires"]
+                    CLAUDE_CODE_CREDENTIALS.write_text(json.dumps(data, indent=2))
+                    logger.info("Updated Claude Code credentials after refresh")
+                except OSError as exc:
+                    logger.warning("Could not update Claude Code credentials: {}", exc)
+                _record_refresh_success("claude", CLAUDE_CODE_CREDENTIALS)
+                return new_cred["access"]
+            _record_refresh_failure("claude", CLAUDE_CODE_CREDENTIALS, new_cred)
 
     # Fall back to Pi auth.json
     auth_data = _read_auth()
@@ -183,12 +423,17 @@ def get_anthropic_token() -> str | None:
 
     now_ms = int(time.time() * 1000)
     if now_ms >= cred.get("expires", 0):
+        if not cred.get("refresh"):
+            _record_refresh_failure("claude", AUTH_FILE, _missing_refresh_token_failure())
+            return None
         logger.info("Pi Anthropic token expired, refreshing...")
         new_cred = _refresh_anthropic(cred)
-        if new_cred:
+        if isinstance(new_cred, dict):
             auth_data["anthropic"] = new_cred
             _write_auth(auth_data)
+            _record_refresh_success("claude", AUTH_FILE)
             return new_cred["access"]
+        _record_refresh_failure("claude", AUTH_FILE, new_cred)
         return None
 
     return cred["access"]
@@ -220,10 +465,42 @@ def get_codex_credentials() -> tuple[str, str] | None:
     if codex_tokens:
         access = codex_tokens["access_token"]
         account_id = codex_tokens.get("account_id") or _extract_codex_account_id(access) or ""
-        # Codex CLI manages its own refresh — we can try the token and let it fail
-        # if expired, then refresh ourselves
-        logger.debug("Using Codex CLI OAuth token (account={}...)", account_id[:8] if account_id else "?")
-        return access, account_id
+        expires = _jwt_expiry_ms(access)
+        now_ms = int(time.time() * 1000)
+        if expires is None or now_ms < expires:
+            logger.debug("Using Codex CLI OAuth token (account={}...)", account_id[:8] if account_id else "?")
+            return access, account_id
+
+        refresh_token = codex_tokens.get("refresh_token")
+        if not refresh_token:
+            _record_refresh_failure(
+                "codex",
+                CODEX_AUTH_FILE,
+                _missing_refresh_token_failure(),
+            )
+        else:
+            logger.info("Codex CLI token expired, refreshing...")
+            new_cred = _refresh_codex({
+                "refresh": refresh_token,
+                "access": access,
+                "expires": expires,
+                "accountId": account_id,
+            })
+            if isinstance(new_cred, dict):
+                try:
+                    data = json.loads(CODEX_AUTH_FILE.read_text())
+                    tokens = data.setdefault("tokens", {})
+                    tokens["access_token"] = new_cred["access"]
+                    tokens["refresh_token"] = new_cred["refresh"]
+                    if new_cred.get("accountId"):
+                        tokens["account_id"] = new_cred["accountId"]
+                    CODEX_AUTH_FILE.write_text(json.dumps(data, indent=2))
+                    logger.info("Updated Codex CLI credentials after refresh")
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning("Could not update Codex CLI credentials: {}", exc)
+                _record_refresh_success("codex", CODEX_AUTH_FILE)
+                return new_cred["access"], new_cred.get("accountId", "")
+            _record_refresh_failure("codex", CODEX_AUTH_FILE, new_cred)
 
     # Fall back to Pi auth.json
     auth_data = _read_auth()
@@ -233,12 +510,17 @@ def get_codex_credentials() -> tuple[str, str] | None:
 
     now_ms = int(time.time() * 1000)
     if now_ms >= cred.get("expires", 0):
+        if not cred.get("refresh"):
+            _record_refresh_failure("codex", AUTH_FILE, _missing_refresh_token_failure())
+            return None
         logger.info("Pi Codex token expired, refreshing...")
         new_cred = _refresh_codex(cred)
-        if new_cred:
+        if isinstance(new_cred, dict):
             auth_data["openai-codex"] = new_cred
             _write_auth(auth_data)
+            _record_refresh_success("codex", AUTH_FILE)
             return new_cred["access"], new_cred.get("accountId", "")
+        _record_refresh_failure("codex", AUTH_FILE, new_cred)
         return None
 
     account_id = cred.get("accountId") or _extract_codex_account_id(cred["access"]) or ""
@@ -265,3 +547,133 @@ def is_codex_available() -> bool:
     auth_data = _read_auth()
     cred = auth_data.get("openai-codex")
     return cred is not None and cred.get("type") == "oauth"
+
+
+def _auth_file_report(path: Path, now_ms: int) -> dict[str, Any]:
+    mtime_ms = _credential_file_mtime_ms(path)
+    return {
+        "credential_file": str(path),
+        "credential_file_mtime_ms": mtime_ms,
+        "credential_file_age_s": (
+            max(0, (now_ms - mtime_ms) // 1000) if mtime_ms is not None else None
+        ),
+    }
+
+
+def _provider_report(
+    provider: str,
+    credential_file: Path,
+    token_expires_at_ms: int | None,
+    now_ms: int,
+    *,
+    configured: bool,
+) -> dict[str, Any]:
+    if not configured:
+        provider_status = "not_configured"
+    elif token_expires_at_ms is None:
+        provider_status = "configured"
+    elif now_ms < token_expires_at_ms:
+        provider_status = "valid"
+    else:
+        provider_status = "expired"
+
+    report = {
+        "status": provider_status,
+        "provider_auth_status": provider_status,
+        **_auth_file_report(credential_file, now_ms),
+        "source": str(credential_file),
+        "token_expires_at_ms": token_expires_at_ms,
+        "expires_in_s": (
+            max(0, (token_expires_at_ms - now_ms) // 1000)
+            if token_expires_at_ms is not None
+            else None
+        ),
+        "last_refresh_outcome": "not_attempted_since_process_start",
+        "last_refresh_at_ms": None,
+        "last_refresh_failure_reason": None,
+        "last_refresh_failure_context": None,
+        "last_refresh_http_status": None,
+        "last_refresh_provider_error_code": None,
+        "last_refresh_error_body_classification": None,
+    }
+
+    last_refresh = _LAST_REFRESH_OUTCOMES.get(provider)
+    if not last_refresh:
+        return report
+
+    report["last_refresh_outcome"] = last_refresh["outcome"]
+    report["last_refresh_at_ms"] = last_refresh["attempted_at_ms"]
+    report["last_refresh_failure_reason"] = last_refresh.get("failure_reason")
+    report["last_refresh_failure_context"] = last_refresh.get("failure_context")
+    report["last_refresh_http_status"] = last_refresh.get("http_status")
+    report["last_refresh_provider_error_code"] = last_refresh.get("provider_error_code")
+    report["last_refresh_error_body_classification"] = last_refresh.get(
+        "provider_error_body_classification"
+    )
+    # A prior failure is current only while the provider is still unusable and
+    # the file has the same container-view mtime. A host-side rotation therefore
+    # clears the warning instead of masking a newly valid credential.
+    same_file_version = (
+        str(credential_file) == last_refresh.get("credential_file")
+        and report["credential_file_mtime_ms"] == last_refresh.get("credential_file_mtime_ms")
+    )
+    if provider_status in {"expired", "not_configured"} and same_file_version:
+        report["provider_auth_status"] = last_refresh["provider_auth_status"]
+        report["project_agent_message"] = last_refresh["project_agent_message"]
+    return report
+
+
+def get_auth_status_snapshot(now_ms: int | None = None) -> dict[str, Any]:
+    """Return per-provider token, file, and refresh diagnostics."""
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+
+    pi_data = _read_auth()
+
+    claude = _read_claude_code_credentials()
+    claude_file = CLAUDE_CODE_CREDENTIALS
+    claude_expiry = claude.get("expiresAt") if claude else None
+    if not claude:
+        pi_claude = pi_data.get("anthropic", {})
+        if pi_claude.get("type") == "oauth":
+            claude = pi_claude
+            claude_file = AUTH_FILE
+            claude_expiry = pi_claude.get("expires")
+    claude_report = _provider_report(
+        "claude", claude_file, claude_expiry, now_ms, configured=bool(claude)
+    )
+    if claude and claude_file == CLAUDE_CODE_CREDENTIALS:
+        claude_report["subscription"] = claude.get("subscriptionType", "unknown")
+        claude_report["rate_tier"] = claude.get("rateLimitTier", "unknown")
+
+    codex = _read_codex_auth()
+    codex_file = CODEX_AUTH_FILE
+    codex_expiry = _jwt_expiry_ms(codex["access_token"]) if codex else None
+    if not codex:
+        pi_codex = pi_data.get("openai-codex", {})
+        if pi_codex.get("type") == "oauth":
+            codex = pi_codex
+            codex_file = AUTH_FILE
+            codex_expiry = pi_codex.get("expires")
+    codex_report = _provider_report(
+        "codex", codex_file, codex_expiry, now_ms, configured=bool(codex)
+    )
+    if codex and codex_file == CODEX_AUTH_FILE:
+        codex_report["account_id"] = (codex.get("account_id") or "")[:12] + "..."
+
+    opencode_report = _provider_report(
+        "opencode",
+        OPENCODE_AUTH_FILE,
+        None,
+        now_ms,
+        configured=OPENCODE_AUTH_FILE.is_file(),
+    )
+    opencode_report["last_refresh_outcome"] = "managed_by_opencode_cli"
+
+    return {
+        "timestamp": now_ms,
+        "staleness_threshold_s": AUTH_STALE_FILE_THRESHOLD_S,
+        "claude": claude_report,
+        "codex": codex_report,
+        "opencode": opencode_report,
+    }

--- a/tests/test_auth_self_healing.py
+++ b/tests/test_auth_self_healing.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scillm.proxy.providers import auth
+
+
+NOW_S = 2_000_000_000.0
+NOW_MS = int(NOW_S * 1000)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_auth_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(auth, "AUTH_FILE", tmp_path / "pi" / "auth.json")
+    monkeypatch.setattr(auth, "CLAUDE_CODE_CREDENTIALS", tmp_path / "claude" / ".credentials.json")
+    monkeypatch.setattr(auth, "CODEX_AUTH_FILE", tmp_path / "codex" / "auth.json")
+    monkeypatch.setattr(auth, "OPENCODE_AUTH_FILE", tmp_path / "opencode" / "auth.json")
+    monkeypatch.setattr(auth, "AUTH_STALE_FILE_THRESHOLD_S", 3600.0)
+    monkeypatch.setattr(auth.time, "time", lambda: NOW_S)
+    auth._LAST_REFRESH_OUTCOMES.clear()
+    yield
+    auth._LAST_REFRESH_OUTCOMES.clear()
+
+
+def _write_claude_credentials(*, mtime_s: float, refresh_token: str | None = "refresh") -> Path:
+    path = auth.CLAUDE_CODE_CREDENTIALS
+    path.parent.mkdir(parents=True)
+    oauth = {
+        "accessToken": "expired-access",
+        "expiresAt": NOW_MS - 1,
+    }
+    if refresh_token is not None:
+        oauth["refreshToken"] = refresh_token
+    path.write_text(json.dumps({"claudeAiOauth": oauth}))
+    os.utime(path, (mtime_s, mtime_s))
+    return path
+
+
+def _jwt(exp_s: int) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp_s}).encode()).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def test_old_file_plus_network_error_classifies_as_stale_bind(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    credential_file = _write_claude_credentials(mtime_s=NOW_S - 7200)
+
+    def raise_network_error(*_args, **_kwargs):
+        raise auth.httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(auth.httpx, "post", raise_network_error)
+
+    assert auth.get_anthropic_token() is None
+
+    report = auth.get_auth_status_snapshot(NOW_MS)["claude"]
+    assert report["provider_auth_status"] == "stale_bind_mount_suspected"
+    assert report["credential_file"] == str(credential_file)
+    assert report["credential_file_mtime_ms"] == int((NOW_S - 7200) * 1000)
+    assert report["token_expires_at_ms"] == NOW_MS - 1
+    assert report["last_refresh_outcome"] == "failed"
+    assert report["last_refresh_failure_reason"] == "network_error"
+    assert report["last_refresh_http_status"] is None
+    assert report["last_refresh_error_body_classification"] == "ambiguous_network_error"
+    assert "directory credential bind mount" in report["project_agent_message"]
+
+
+def test_old_file_plus_invalid_grant_classifies_as_needs_human_login(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_claude_credentials(mtime_s=NOW_S - 7200)
+
+    def invalid_grant_response(*_args, **_kwargs):
+        request = auth.httpx.Request("POST", auth.ANTHROPIC_TOKEN_URL)
+        return auth.httpx.Response(
+            400,
+            request=request,
+            json={
+                "error": "invalid_grant",
+                "error_description": "The refresh token has been revoked",
+            },
+        )
+
+    monkeypatch.setattr(auth.httpx, "post", invalid_grant_response)
+
+    assert auth.get_anthropic_token() is None
+
+    report = auth.get_auth_status_snapshot(NOW_MS)["claude"]
+    assert report["provider_auth_status"] == "needs_human_login"
+    assert report["last_refresh_outcome"] == "failed"
+    assert report["last_refresh_failure_reason"] == "http_error"
+    assert report["last_refresh_http_status"] == 400
+    assert report["last_refresh_provider_error_code"] == "invalid_grant"
+    assert report["last_refresh_error_body_classification"] == "login_required_invalid_grant"
+    assert "CLI login" in report["project_agent_message"]
+    assert "directory credential bind mount" not in report["project_agent_message"]
+
+
+def test_current_mtime_keeps_failed_refresh_as_needs_human_login(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_claude_credentials(mtime_s=NOW_S - 30)
+    monkeypatch.setattr(auth, "_refresh_anthropic", lambda _cred: None)
+
+    assert auth.get_anthropic_token() is None
+
+    report = auth.get_auth_status_snapshot(NOW_MS)["claude"]
+    assert report["provider_auth_status"] == "needs_human_login"
+    assert report["last_refresh_outcome"] == "failed"
+    assert "CLI login" in report["project_agent_message"]
+    assert "directory credential bind mount" not in report["project_agent_message"]
+
+
+def test_missing_refresh_token_in_old_file_is_ambiguous_stale_bind():
+    _write_claude_credentials(mtime_s=NOW_S - 7200, refresh_token=None)
+
+    assert auth.get_anthropic_token() is None
+
+    report = auth.get_auth_status_snapshot(NOW_MS)["claude"]
+    assert report["provider_auth_status"] == "stale_bind_mount_suspected"
+    assert report["last_refresh_outcome"] == "failed"
+    assert report["last_refresh_failure_reason"] == "missing_refresh_token"
+    assert (
+        report["last_refresh_error_body_classification"]
+        == "ambiguous_missing_refresh_token"
+    )
+
+
+def test_auth_snapshot_reports_codex_expiry_mtime_and_refresh_outcome():
+    path = auth.CODEX_AUTH_FILE
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"tokens": {"access_token": _jwt(int(NOW_S + 900))}}))
+    os.utime(path, (NOW_S - 45, NOW_S - 45))
+
+    report = auth.get_auth_status_snapshot(NOW_MS)["codex"]
+
+    assert report["provider_auth_status"] == "valid"
+    assert report["token_expires_at_ms"] == int((NOW_S + 900) * 1000)
+    assert report["expires_in_s"] == 900
+    assert report["credential_file_mtime_ms"] == int((NOW_S - 45) * 1000)
+    assert report["last_refresh_outcome"] == "not_attempted_since_process_start"
+
+
+def test_codex_failed_refresh_uses_the_same_mtime_staleness_rule(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = auth.CODEX_AUTH_FILE
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "tokens": {
+                    "access_token": _jwt(int(NOW_S - 60)),
+                    "refresh_token": "refresh",
+                }
+            }
+        )
+    )
+    os.utime(path, (NOW_S - 7200, NOW_S - 7200))
+
+    def raise_network_error(*_args, **_kwargs):
+        raise auth.httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(auth.httpx, "post", raise_network_error)
+
+    assert auth.get_codex_credentials() is None
+
+    report = auth.get_auth_status_snapshot(NOW_MS)["codex"]
+    assert report["provider_auth_status"] == "stale_bind_mount_suspected"
+    assert report["last_refresh_outcome"] == "failed"
+    assert report["last_refresh_failure_reason"] == "network_error"
+    assert report["last_refresh_error_body_classification"] == "ambiguous_network_error"
+
+
+def test_successful_claude_refresh_is_written_back_and_reported(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    path = _write_claude_credentials(mtime_s=NOW_S - 7200)
+    monkeypatch.setattr(
+        auth,
+        "_refresh_anthropic",
+        lambda _cred: {
+            "access": "new-access",
+            "refresh": "new-refresh",
+            "expires": NOW_MS + 3600 * 1000,
+        },
+    )
+
+    assert auth.get_anthropic_token() == "new-access"
+
+    written = json.loads(path.read_text())["claudeAiOauth"]
+    assert written["accessToken"] == "new-access"
+    assert written["refreshToken"] == "new-refresh"
+    assert written["expiresAt"] == NOW_MS + 3600 * 1000
+    report = auth.get_auth_status_snapshot(NOW_MS)["claude"]
+    assert report["provider_auth_status"] == "valid"
+    assert report["last_refresh_outcome"] == "succeeded"
+
+
+def test_core_compose_uses_writable_directory_mounts_and_durable_config():
+    compose = Path("deploy/docker/compose.scillm.core.yml").read_text()
+
+    assert "${HOME}/.pi/agent:/root/.pi/agent\"" in compose
+    assert "${HOME}/.claude:/root/.claude\"" in compose
+    assert "${HOME}/.codex:/root/.codex\"" in compose
+    assert "${HOME}/.local/share/opencode:/root/.local/share/opencode\"" in compose
+    assert "${HOME}/.claude/.credentials.json" not in compose
+    assert "${HOME}/.codex/auth.json" not in compose
+    assert "${HOME}/.pi/agent/auth.json" not in compose
+    assert "${HOME}/.local/share/opencode/auth.json" not in compose
+    assert "${SCILLM_REPO_ROOT:-/home/graham/workspace/experiments/scillm}" in compose
+    assert "../../local/proxy_server_config.yaml:/app/config.yaml" not in compose


### PR DESCRIPTION
Closes #22.

Reviewed via tau coder-reviewer loop: codex coder + gpt-5.5-high reviewer, iteration-2 VERDICT: PASS (iteration-1 NEEDS_ATTENTION blocker — classification could mask a genuine needs_human_login — resolved with explicit precedence and both-direction tests).

- Credential mounts become parent-directory mounts so atomic-rename rotation stays visible (root cause of the dead opus-4.8 seat: container held a day-old inode of .credentials.json while the host token was valid — verified by inode comparison).
- Config mount moved off a deleted /tmp worktree path (that path took the proxy down during a restart).
- Refresh failures preserve provider error context: invalid_grant/revoked/401-403 → needs_human_login regardless of file age; ambiguous failures with old files → stale_bind_mount_suspected with actionable remedy.
- /v1/scillm/auth reports per-provider expiry, credential-file mtime/age, last refresh outcome.
- tests/test_auth_self_healing.py: 8 passed (independently rerun by the project agent).

Note: the running container was deliberately not touched; compose changes apply on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)