### PR TITLE
Recover Claude OAuth provider calls

### DIFF
--- a/embry-voice-blocker-mvp-20260726.md
+++ b/embry-voice-blocker-mvp-20260726.md
@@ -1,0 +1,105 @@
+# Embry Voice Blocker MVP
+
+Immutable Goal: NOT_MET
+
+## What The Smallest MVP Proves
+
+MVP prompt:
+
+```text
+Hey Embry, what is the capital of France?
+```
+
+MVP command:
+
+```bash
+OUT_DIR=/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r8 \
+  bash /tmp/embry-voice-mvp-problem-20260726T2012Z/run_mvp.sh
+```
+
+Receipt:
+
+```text
+/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r8/summary.json
+```
+
+Result:
+
+- `pass: true`
+- `mocked: false`
+- `live: true`
+- `checks.embry_live_turn.status: ok`
+- `checks.embry_live_turn.answerAuthority: wikipedia_rest`
+- `checks.embry_live_turn.answerText: Wikipedia's List of capitals of France result says: The capital of France has been Paris since its liberation in 1944.`
+- Chatterbox render receipt: `/tmp/chatterbox-fork-agent-out/ux-lab-embry-direct/2026-07-26T20-45-33-029Z-a912bdabfee8.json`
+- Chatterbox WAV: `/tmp/chatterbox-fork-agent-out/ux-lab-embry-direct/2026-07-26T20-45-33-029Z-a912bdabfee8.wav`
+
+This proves only the narrow typed/live-turn path:
+
+```text
+text prompt -> Memory intent says outside_memory_domains ->
+SPARTA live-turn -> Wikipedia REST dynamic answer ->
+Chatterbox render -> amplitude frame data exists
+```
+
+## Where Progress Is Still Not Proven
+
+This MVP does not prove the immutable voice goal.
+
+Missing proof:
+
+- wake word detection from actual audio: `Hey Embry`
+- Jabra microphone capture as the input source
+- RealtimeSTT final transcript from that fresh Jabra capture
+- first voice asks a question, Embry answers, and conversation turn state persists
+- Memory/Tau-generated conversational answer; Tau still times out in the MVP diagnostics
+- Chatterbox playback through Jabra speaker for the fresh turn
+- SPARTA Chat UX replay sourced from the authoritative journal
+- Embry orb CDP proof showing state and amplitude/frequency-driven particle motion for that fresh turn
+
+## Ask Competition Result
+
+Ask competition run:
+
+```text
+/mnt/storage12tb/skills/ask/outputs/embry-voice-minimum-mvp-competition-20260726T2018Z/ask-tau-minimum-mvp-competition-for-the--c8c97a5f8e87
+```
+
+DAG receipt:
+
+```text
+/mnt/storage12tb/skills/ask/outputs/embry-voice-minimum-mvp-competition-20260726T2018Z/ask-tau-minimum-mvp-competition-for-the--c8c97a5f8e87/tau-receipts/dag-receipt.json
+```
+
+Result:
+
+- `status: BLOCKED`
+- `ok: false`
+- `verdict: COMMAND_FAILED`
+- `mocked: false`
+- `live: true`
+
+Handler outcome:
+
+- `webkimi`: produced a useful repair path
+- `webgpt`: `repo_access_blocked`
+- `webgrok`: `browser_tab_identity_mismatch`
+- `webclaude`: `browser_tab_read_timeout`
+
+Useful WebKimi artifact:
+
+```text
+/mnt/storage12tb/skills/ask/outputs/embry-voice-minimum-mvp-competition-20260726T2018Z/ask-tau-minimum-mvp-competition-for-the--c8c97a5f8e87/node-artifacts/handler-webkimi/response.md
+```
+
+## Current Blocker Statement
+
+The blocker is not that every component is absent. The blocker is that I do not yet have a fresh deterministic receipt for the actual voice loop:
+
+```text
+audio wake -> RealtimeSTT final transcript -> SPARTA live-turn ->
+dynamic answer -> Chatterbox render -> Jabra playback ->
+journal replay -> orb CDP proof
+```
+
+The smallest passing MVP narrowed one bug and repaired the typed live-turn route. It is not a substitute for the actual acoustic conversation proof.

--- a/embry-voice-blocker-mvp-20260726.md
+++ b/embry-voice-blocker-mvp-20260726.md
@@ -103,3 +103,102 @@ journal replay -> orb CDP proof
 ```
 
 The smallest passing MVP narrowed one bug and repaired the typed live-turn route. It is not a substitute for the actual acoustic conversation proof.
+
+## Fresh Rerun Learning: 2026-07-26T21:35Z
+
+Fresh MVP command:
+
+```bash
+OUT_DIR=/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r9-20260726T213537Z \
+  bash /tmp/embry-voice-mvp-problem-20260726T2012Z/run_mvp.sh
+```
+
+Fresh receipt:
+
+```text
+/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r9-20260726T213537Z/summary.json
+```
+
+Result:
+
+- `pass: true`
+- `mocked: false`
+- `live: true`
+- `checks.memory_intent.action: NO_MATCH`
+- `checks.memory_intent.reason: outside_memory_domains`
+- `checks.memory_answer_unix.error: curl_failed_or_timed_out`
+- `checks.memory_answer_http.can_answer: false`
+- `checks.tau_chat_turn.error: curl_failed_or_timed_out`
+- `checks.embry_live_turn.answerAuthority: wikipedia_rest`
+- `checks.embry_live_turn.answerText: Wikipedia's List of capitals of France result says: The capital of France has been Paris since its liberation in 1944.`
+
+Fresh Chatterbox render:
+
+```text
+/home/graham/workspace/experiments/chatterbox/logs/ux-lab-embry-direct/2026-07-26T21-36-48-714Z-a912bdabfee8.json
+/home/graham/workspace/experiments/chatterbox/logs/ux-lab-embry-direct/2026-07-26T21-36-48-714Z-a912bdabfee8.wav
+```
+
+Render facts:
+
+- `backend: chatterbox-direct`
+- `engine: chatterbox_turbo`
+- `generation_seconds: 2.27`
+- `duration_seconds: 7.08`
+- `realtime_factor: 0.321`
+- WAV: PCM 16-bit mono, 24000 Hz, 339918 bytes
+- `audio_authority.envelope.frame_count: 443`
+- `audio_authority.envelope.nonzero_frames: 442`
+- envelope has nonzero `level`, `rms`, `bass`, `mid`, and `treble` fields suitable for orb animation input
+
+Jabra playback attempt:
+
+```text
+/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r9-20260726T213537Z/jabra-playback-attempt.json
+```
+
+Result:
+
+- `mocked: false`
+- `live: true`
+- target: `alsa_output.usb-0b0e_Jabra_SPEAK_510_USB_501AA5274B1D022000-00.analog-stereo`
+- `returncode: 0`
+
+Jabra microphone capture during playback:
+
+```text
+/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r9-20260726T213537Z/jabra-mic-capture-20260726T213849Z.json
+```
+
+Result:
+
+- `mocked: false`
+- `live: true`
+- record target: `alsa_input.usb-0b0e_Jabra_SPEAK_510_USB_501AA5274B1D022000-00.mono-fallback`
+- capture WAV: `/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r9-20260726T213537Z/jabra-mic-capture-20260726T213849Z.wav`
+- `capture_bytes: 477168`
+- `duration_seconds: 9.940083`
+- `mean_volume_db: -50.6`
+- `max_volume_db: -37.6`
+- `playback_returncode: 0`
+- `record_returncode: 124`, because timeout ended the bounded recording window
+
+RealtimeSTT/Whisper check against that Jabra mic capture:
+
+```text
+/tmp/embry-voice-mvp-problem-20260726T2012Z/results-r9-20260726T213537Z/jabra-mic-capture-realtimestt-whisper-container-key.json
+```
+
+Result:
+
+- `ok: false`
+- `mocked: false`
+- `live: false`
+- failed gate: `realtimestt_transcript_present`
+- OpenAI-compatible Whisper executor was reached with the actual container key
+- `asr_executor_call_count: 1`
+- ASR transcript: empty string
+
+New learning:
+
+The MVP answer can be dynamically generated, rendered by Chatterbox, and played to the Jabra speaker. The Jabra mic records a real but quiet signal during that playback. Feeding that captured WAV into the RealtimeSTT bridge reaches the live Whisper executor, but the executor returns an empty transcript. The current smallest blocker is therefore below SPARTA and Chatterbox: the acoustic/Jabra capture level or capture route is not producing ASR-usable speech for this playback loop.

--- a/embry-voice-blocker-mvp-20260726.md
+++ b/embry-voice-blocker-mvp-20260726.md
@@ -269,6 +269,24 @@ Result:
 - Jabra-mic-captured WAV -> Whisper HTTP 200 and empty transcript: `{"text":""}`
 - gain/filter attempts at `volume=12dB`, `volume=20dB`, `highpass/lowpass + 20dB`, and `afftdn + 18dB` still returned empty transcripts
 
+Direct RealtimeSTT bridge separation:
+
+```text
+/tmp/embry-realtimestt-source-bridge-20260726T230101Z/realtimestt-source-asr.json
+```
+
+Result:
+
+- `ok: true`
+- `mocked: false`
+- `live: true`
+- failed gates: `[]`
+- live OpenAI-compatible Whisper executor call count: `1`
+- transcript:
+  `Wikipedia's list of capitals of France's result says the capital of France has been Paris since its liberation in 1944.`
+
+This proves the RealtimeSTT bridge and Whisper executor can produce text when the input WAV is intelligible.
+
 Device-state checks:
 
 - `wpctl get-volume 33`: `Volume: 1.00`
@@ -291,9 +309,26 @@ Result:
 - max volume: `-29.6 dB`
 - direct Whisper response: `{"text":""}`
 
+Non-Jabra speaker output check:
+
+```text
+/tmp/embry-jabra-acoustic-debug-usb-speakers-20260726T230028Z/summary.json
+```
+
+Result:
+
+- playback target: `alsa_output.usb-Generic_USB_Audio-00.HiFi__hw_ALC1220VBDT__sink`
+- record target: `alsa_input.usb-0b0e_Jabra_SPEAK_510_USB_501AA5274B1D022000-00.mono-fallback`
+- capture WAV existed, `478192` bytes, `9.961417` seconds
+- mean volume: `-42.5 dB`
+- max volume: `-28.6 dB`
+- live Whisper executor reached once through RealtimeSTT
+- failed gate: `realtimestt_transcript_present`
+- transcript: empty string
+
 Current conclusion:
 
-Memory is not the current acoustic blocker. The Whisper ASR service is not generally broken because it transcribes the original Chatterbox WAV. PipeWire is not showing the Jabra source as muted, and ALSA also reports the mic capture switch as on. The failing layer is the Jabra acoustic loopback/capture quality or Jabra hardware DSP path: the Jabra speaker can play the answer, but the Jabra mic capture of that playback is not ASR-usable.
+Memory is not the current acoustic blocker. The Whisper ASR service is not generally broken because it transcribes the original Chatterbox WAV. The RealtimeSTT bridge is not generally broken because it also transcribes the original Chatterbox WAV through the same live executor. PipeWire is not showing the Jabra source as muted, and ALSA also reports the mic capture switch as on. The failing layer is the physical/acoustic capture path: Jabra mic recordings of speaker playback are not ASR-usable in the current workstation setup.
 
 ## Ask/Surf Competition Failure Ticket
 

--- a/embry-voice-blocker-mvp-20260726.md
+++ b/embry-voice-blocker-mvp-20260726.md
@@ -202,3 +202,122 @@ Result:
 New learning:
 
 The MVP answer can be dynamically generated, rendered by Chatterbox, and played to the Jabra speaker. The Jabra mic records a real but quiet signal during that playback. Feeding that captured WAV into the RealtimeSTT bridge reaches the live Whisper executor, but the executor returns an empty transcript. The current smallest blocker is therefore below SPARTA and Chatterbox: the acoustic/Jabra capture level or capture route is not producing ASR-usable speech for this playback loop.
+
+## Fresh Acoustic Debugger Proof: 2026-07-26T22:56Z
+
+Debugger script committed in Chatterbox:
+
+```text
+/home/graham/workspace/experiments/chatterbox/scripts/debug_embry_jabra_acoustic_mvp.sh
+```
+
+Chatterbox branch/commit:
+
+```text
+persona-dream-emotion-render-endpoint ac3291c7ad622b4eb95db576b206b28cf82e3e9d
+```
+
+Remote ref verification:
+
+```text
+ac3291c7ad622b4eb95db576b206b28cf82e3e9d refs/heads/persona-dream-emotion-render-endpoint
+```
+
+Live command after restarting the local Whisper container:
+
+```bash
+OUT_DIR=/tmp/embry-jabra-acoustic-debug-whisper-up-20260726T225605Z \
+  /home/graham/workspace/experiments/chatterbox/scripts/debug_embry_jabra_acoustic_mvp.sh
+```
+
+Summary receipt:
+
+```text
+/tmp/embry-jabra-acoustic-debug-whisper-up-20260726T225605Z/summary.json
+```
+
+Result:
+
+- `pass: false`
+- `mocked: false`
+- `live: true`
+- Jabra playback target: `alsa_output.usb-0b0e_Jabra_SPEAK_510_USB_501AA5274B1D022000-00.analog-stereo`
+- Jabra record target: `alsa_input.usb-0b0e_Jabra_SPEAK_510_USB_501AA5274B1D022000-00.mono-fallback`
+- capture WAV: `/tmp/embry-jabra-acoustic-debug-whisper-up-20260726T225605Z/jabra-mic-capture.wav`
+- `capture_bytes: 477168`
+- `duration_seconds: 9.940083`
+- `mean_volume_db: -42.6`
+- `max_volume_db: -17.2`
+- `playback_returncode: 0`
+- `record_returncode: 124`, from the bounded recording timeout
+- RealtimeSTT fed `498` audio chunks and `70` trailing-silence chunks
+- live OpenAI-compatible Whisper executor was reached once
+- failed gate: `realtimestt_transcript_present`
+- transcript: empty string
+
+Direct ASR separation:
+
+```text
+/tmp/embry-jabra-acoustic-debug-whisper-up-20260726T225605Z/direct-whisper-source.json
+/tmp/embry-jabra-acoustic-debug-whisper-up-20260726T225605Z/direct-whisper-captured.json
+```
+
+Result:
+
+- original Chatterbox source WAV -> Whisper HTTP 200 and non-empty transcript:
+  `Wikipedia's list of capitals of France's results says the capital of France has been Paris since its liberation in 1944.`
+- Jabra-mic-captured WAV -> Whisper HTTP 200 and empty transcript: `{"text":""}`
+- gain/filter attempts at `volume=12dB`, `volume=20dB`, `highpass/lowpass + 20dB`, and `afftdn + 18dB` still returned empty transcripts
+
+Device-state checks:
+
+- `wpctl get-volume 33`: `Volume: 1.00`
+- `wpctl get-volume 58`: `Volume: 0.90`
+- `pw-cli enum-params 33 Props`: `mute false`, `softMute false`, source volume `1.000000`
+- `amixer -c 1 scontents`: Jabra `Mic` capture `7 [100%] [9.00dB] [on]`
+
+Direct ALSA duplex check:
+
+```text
+/tmp/embry-jabra-alsa-duplex-20260726T225734Z/summary.json
+```
+
+Result:
+
+- ALSA playback return code: `0`
+- ALSA mic capture WAV: `/tmp/embry-jabra-alsa-duplex-20260726T225734Z/alsa-jabra-mic-capture.wav`
+- duration: `10.000000`
+- mean volume: `-42.9 dB`
+- max volume: `-29.6 dB`
+- direct Whisper response: `{"text":""}`
+
+Current conclusion:
+
+Memory is not the current acoustic blocker. The Whisper ASR service is not generally broken because it transcribes the original Chatterbox WAV. PipeWire is not showing the Jabra source as muted, and ALSA also reports the mic capture switch as on. The failing layer is the Jabra acoustic loopback/capture quality or Jabra hardware DSP path: the Jabra speaker can play the answer, but the Jabra mic capture of that playback is not ASR-usable.
+
+## Ask/Surf Competition Failure Ticket
+
+The MVP `$ask competition` for this acoustic blocker produced zero candidate implementations because browser-oracle transport failed before reviewer output.
+
+Competition DAG receipt:
+
+```text
+/mnt/storage12tb/skills/ask/outputs/embry-jabra-acoustic-mvp-competition-20260726T2259Z/ask-tau-embry-jabra-acoustic-mvp-competi-fa2dece807a5/tau-receipts/dag-receipt.json
+```
+
+Result:
+
+- `status: BLOCKED`
+- `ok: false`
+- `verdict: COMMAND_FAILED`
+- `provider_live: false`
+- `handler-webclaude`: invalid tab id
+- `handler-webkimi`: invalid tab id
+- `handler-webgrok`: missing live tab
+- `handler-webgpt`: local-path preflight rejection; requested concatenated text or small zip
+
+Filed ticket:
+
+```text
+https://github.com/grahama1970/agent-skills/issues/1024
+```

--- a/registry/caller_profiles.example.yaml
+++ b/registry/caller_profiles.example.yaml
@@ -11,7 +11,7 @@ caller_profiles:
     max_timeout_s: 60
 
   create-evidence-case:
-    allowed_models: [gemini-flash]
+    allowed_models: [gemini-flash, deepseek-ai/DeepSeek-V3.2-TEE]
     deny_model_patterns: ["gpt-*", "codex-*", "claude-*", "vlm-*", "qra-*"]
     allow_tools: false
     allow_files: false

--- a/registry/caller_profiles.example.yaml
+++ b/registry/caller_profiles.example.yaml
@@ -10,8 +10,18 @@ caller_profiles:
     allow_streaming: false
     max_timeout_s: 60
 
+  create-evidence-case:
+    allowed_models: [gemini-flash]
+    deny_model_patterns: ["gpt-*", "codex-*", "claude-*", "vlm-*", "qra-*"]
+    allow_tools: false
+    allow_files: false
+    allow_images: false
+    allow_pdfs: false
+    allow_streaming: false
+    max_timeout_s: 60
+
   pdf-extraction-review:
-    allowed_models: [vlm-chutes, vlm-claude, gpt-5.5]
+    allowed_models: [vlm-claude, gpt-5.5]
     allow_images: true
     allow_pdfs: true
     allow_tools: false

--- a/scripts/generate_image.py
+++ b/scripts/generate_image.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Generate an image from a repo prompt file and write PNG + receipt.
+
+Default auth: Codex OAuth (`codex login`) via built-in image_gen in `codex exec`.
+Optional auth: OpenAI API key via scillm POST /v1/images/generations (automation/CI).
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import select
+import shutil
+import struct
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+PROGRESS_PREFIX = "scillm.image."
+
+
+def emit_progress(event_type: str, **fields: Any) -> None:
+    payload = {"type": f"{PROGRESS_PREFIX}{event_type}", **fields}
+    print(json.dumps(payload), file=sys.stderr, flush=True)
+
+DEFAULT_BASE = "http://127.0.0.1:4001"
+DEFAULT_MODEL = "gpt-image-2"
+PROMPT_MAX_CHARS = 32_000
+DEFAULT_TIMEOUT_S = 600.0
+
+
+def _png_dimensions(data: bytes) -> tuple[int | None, int | None]:
+    if len(data) < 24 or data[:8] != b"\x89PNG\r\n\x1a\n":
+        return None, None
+    width, height = struct.unpack(">II", data[16:24])
+    return int(width), int(height)
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _load_prompt(path: Path) -> str:
+    prompt = path.read_text(encoding="utf-8").strip()
+    if not prompt:
+        raise ValueError(f"prompt file is empty: {path}")
+    if len(prompt) > PROMPT_MAX_CHARS:
+        raise ValueError(
+            f"prompt length {len(prompt)} exceeds limit {PROMPT_MAX_CHARS} characters"
+        )
+    return prompt
+
+
+def _receipt_path_for_image(image_path: Path) -> Path:
+    return image_path.with_name(f"{image_path.stem}_receipt.json")
+
+
+def _default_timeout_s() -> float:
+    raw = os.getenv("SCILLM_IMAGE_TIMEOUT_S")
+    if raw is None or not raw.strip():
+        return DEFAULT_TIMEOUT_S
+    try:
+        timeout = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"SCILLM_IMAGE_TIMEOUT_S must be numeric, got {raw!r}") from exc
+    if timeout <= 0:
+        raise ValueError(f"SCILLM_IMAGE_TIMEOUT_S must be positive, got {timeout!r}")
+    return timeout
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload) + "\n")
+        handle.flush()
+
+
+def _write_receipt(
+    *,
+    out: Path,
+    receipt_file: Path,
+    png_bytes: bytes,
+    prompt_file: Path,
+    prompt: str,
+    auth: str,
+    provider: str,
+    model: str,
+    caller_skill: str | None = None,
+    endpoint: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    width, height = _png_dimensions(png_bytes)
+    receipt: dict[str, Any] = {
+        "ok": True,
+        "auth": auth,
+        "path": str(out),
+        "width": width,
+        "height": height,
+        "sha256": _sha256_hex(png_bytes),
+        "bytes": len(png_bytes),
+        "model": model,
+        "provider": provider,
+        "prompt_file": str(prompt_file.resolve()),
+        "prompt_chars": len(prompt),
+        "prompt_sha256": _sha256_hex(prompt.encode("utf-8")),
+        "endpoint": endpoint,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if caller_skill:
+        receipt["caller_skill"] = caller_skill
+    if extra:
+        receipt.update(extra)
+    receipt_file.parent.mkdir(parents=True, exist_ok=True)
+    receipt_file.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    receipt["receipt_path"] = str(receipt_file)
+    return receipt
+
+
+def _codex_oauth_available() -> bool:
+    try:
+        from scillm.proxy.providers.auth import get_codex_credentials
+
+        return get_codex_credentials() is not None
+    except Exception:
+        pass
+    auth_path = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "auth.json"
+    try:
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    tokens = data.get("tokens")
+    if isinstance(tokens, dict) and tokens.get("access_token"):
+        return True
+    return bool(data.get("OPENAI_API_KEY"))
+
+
+def _summarize_event(event: dict[str, Any]) -> str:
+    kind = event.get("type", "?")
+    if kind == "item.completed":
+        item = event.get("item") or {}
+        return f"{kind}:{item.get('type', '?')}"
+    return str(kind)
+
+
+def _newest_png_under(root: Path, since: float) -> Path | None:
+    candidates = [
+        p
+        for p in root.rglob("*.png")
+        if p.is_file() and p.stat().st_mtime >= since - 2
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _output_and_receipt_ready(out: Path, receipt_file: Path) -> bool:
+    if not out.is_file() or out.stat().st_size == 0 or not receipt_file.is_file():
+        return False
+    try:
+        receipt = json.loads(receipt_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if receipt.get("ok") is not True:
+        return False
+    recorded = str(receipt.get("sha256") or "")
+    if not recorded:
+        return True
+    return recorded == _sha256_hex(out.read_bytes())
+
+
+def generate_image_openai_api(
+    *,
+    prompt_file: Path,
+    out: Path,
+    model: str = DEFAULT_MODEL,
+    quality: str = "high",
+    size: str = "auto",
+    background: str | None = None,
+    output_format: str = "png",
+    base_url: str = DEFAULT_BASE,
+    master_key: str,
+    caller_skill: str,
+    receipt_path: Path | None = None,
+    timeout_s: float = 300.0,
+) -> dict[str, Any]:
+    prompt = _load_prompt(prompt_file)
+    emit_progress("started", auth="openai-api-key", model=model, prompt_chars=len(prompt))
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "size": size,
+        "quality": quality,
+        "response_format": "b64_json",
+        "output_format": output_format,
+        "n": 1,
+    }
+    if background:
+        payload["background"] = background
+
+    headers = {
+        "Authorization": f"Bearer {master_key}",
+        "Content-Type": "application/json",
+        "X-Caller-Skill": caller_skill,
+    }
+    url = f"{base_url.rstrip('/')}/v1/images/generations"
+
+    started = time.monotonic()
+    with httpx.Client(timeout=timeout_s) as client:
+        response = client.post(url, headers=headers, json=payload)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"scillm images API HTTP {response.status_code}: {response.text[:500]}"
+            )
+        body = response.json()
+
+    data = body.get("data") or []
+    if not data:
+        raise RuntimeError(f"scillm images API returned no data: {body}")
+    item = data[0]
+    b64 = item.get("b64_json")
+    if not b64:
+        raise RuntimeError(f"scillm images API missing b64_json: {item}")
+
+    png_bytes = base64.b64decode(b64)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(png_bytes)
+
+    receipt_file = receipt_path or _receipt_path_for_image(out)
+    receipt = _write_receipt(
+        out=out,
+        receipt_file=receipt_file,
+        png_bytes=png_bytes,
+        prompt_file=prompt_file,
+        prompt=prompt,
+        auth="openai-api-key",
+        provider=str(body.get("provider") or "openai"),
+        model=str(body.get("model") or model),
+        caller_skill=caller_skill,
+        endpoint="/v1/images/generations",
+        extra={
+            "quality": quality,
+            "size": size,
+            "model_requested": body.get("model_requested"),
+            "revised_prompt": item.get("revised_prompt"),
+            "scillm": body.get("scillm"),
+        },
+    )
+    scillm_meta = body.get("scillm") or {}
+    emit_progress(
+        "completed",
+        auth="openai-api-key",
+        ok=True,
+        terminal=True,
+        elapsed_ms=scillm_meta.get("elapsed_ms") or int((time.monotonic() - started) * 1000),
+        scillm_status=scillm_meta.get("status", "completed"),
+        path=str(out),
+        receipt_path=str(receipt_file),
+        sha256=receipt["sha256"],
+        width=receipt["width"],
+        height=receipt["height"],
+    )
+    return receipt
+
+
+def generate_image_codex_oauth(
+    *,
+    prompt_file: Path,
+    out: Path,
+    cwd: Path,
+    receipt_path: Path | None = None,
+    timeout_s: float | None = None,
+    first_event_s: float = 30.0,
+    bypass_sandbox: bool = True,
+    bypass_hooks: bool = True,
+    events_out: Path | None = None,
+) -> dict[str, Any]:
+    prompt = _load_prompt(prompt_file)
+    timeout_s = _default_timeout_s() if timeout_s is None else timeout_s
+    if timeout_s <= 0:
+        raise ValueError(f"timeout_s must be positive, got {timeout_s!r}")
+    emit_progress("started", auth="codex-oauth", prompt_chars=len(prompt))
+    if not _codex_oauth_available():
+        raise RuntimeError(
+            "Codex OAuth not available. Run `codex login` (ChatGPT subscription) or use --auth openai-api-key."
+        )
+    out = out.resolve()
+    receipt_file = (receipt_path or _receipt_path_for_image(out)).resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+
+    exec_prompt = (
+        "Use the built-in image_gen tool only (Codex OAuth subscription). "
+        "Do NOT use scripts/image_gen.py, curl, or OPENAI_API_KEY.\n\n"
+        f"1) Generate the image from this spec using image_gen.\n"
+        f"2) Copy/move the final PNG to exactly: {out}\n"
+        f"3) Write receipt JSON to exactly: {receipt_file} with keys "
+        "ok, auth, path, width, height, sha256 (compute sha256 from the PNG bytes).\n"
+        "4) Reply DONE only when both files exist.\n\n"
+        "IMAGE SPEC:\n" + prompt
+    )
+
+    cmd = [
+        "codex",
+        "exec",
+        "--json",
+        "--sandbox",
+        "workspace-write",
+        "-C",
+        str(cwd.resolve()),
+    ]
+    if bypass_sandbox:
+        cmd.append("--dangerously-bypass-approvals-and-sandbox")
+    if bypass_hooks:
+        cmd.append("--dangerously-bypass-hook-trust")
+    cmd.append(exec_prompt)
+
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdout is not None
+
+    events: list[dict[str, Any]] = []
+    event_count = 0
+    thread_id: str | None = None
+
+    while True:
+        elapsed = time.monotonic() - started
+        if event_count == 0 and elapsed > first_event_s:
+            proc.kill()
+            raise RuntimeError(
+                f"no codex JSON events within {first_event_s:.0f}s (use stdin=closed; check codex login)"
+            )
+        if elapsed > timeout_s:
+            proc.kill()
+            raise RuntimeError(f"codex exec exceeded timeout {timeout_s:.0f}s after {event_count} events")
+
+        ready, _, _ = select.select([proc.stdout], [], [], 1.0)
+        if not ready:
+            if _output_and_receipt_ready(out, receipt_file):
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                break
+            continue
+        line = proc.stdout.readline()
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event_count += 1
+        events.append(event)
+        if events_out:
+            _append_jsonl(events_out, event)
+        if event.get("type") == "thread.started":
+            thread_id = event.get("thread_id")
+        print(f"[codex +{elapsed:5.1f}s] #{event_count} {_summarize_event(event)}", flush=True)
+
+    rc = proc.wait()
+    stderr = proc.stderr.read().strip() if proc.stderr else ""
+
+    if rc != 0 and not _output_and_receipt_ready(out, receipt_file):
+        raise RuntimeError(f"codex exec failed rc={rc}: {stderr[:500]}")
+
+    if not out.is_file() or out.stat().st_size == 0:
+        codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+        since = started + time.time() - time.monotonic() - 5
+        search_roots = [codex_home / "generated_images"]
+        if thread_id:
+            search_roots.insert(0, codex_home / "generated_images" / thread_id)
+        fallback: Path | None = None
+        for root in search_roots:
+            if root.is_dir():
+                fallback = _newest_png_under(root, since)
+                if fallback:
+                    break
+        if fallback is None:
+            raise RuntimeError(
+                "codex finished but workspace PNG missing and no recent ~/.codex/generated_images PNG found"
+            )
+        shutil.copy2(fallback, out)
+        print(f"copied fallback {fallback} -> {out}", flush=True)
+
+    png_bytes = out.read_bytes()
+    if receipt_file.is_file():
+        try:
+            saved = json.loads(receipt_file.read_text(encoding="utf-8"))
+            if saved.get("ok"):
+                saved.setdefault("auth", "codex-oauth")
+                saved.setdefault("path", str(out))
+                saved["receipt_path"] = str(receipt_file)
+                emit_progress(
+                    "completed",
+                    auth="codex-oauth",
+                    ok=True,
+                    terminal=True,
+                    elapsed_ms=int((time.monotonic() - started) * 1000),
+                    scillm_status="completed",
+                    path=str(out),
+                    receipt_path=str(receipt_file),
+                    sha256=saved.get("sha256"),
+                    width=saved.get("width"),
+                    height=saved.get("height"),
+                    codex_events=event_count,
+                )
+                return saved
+        except json.JSONDecodeError:
+            pass
+
+    receipt = _write_receipt(
+        out=out,
+        receipt_file=receipt_file,
+        png_bytes=png_bytes,
+        prompt_file=prompt_file,
+        prompt=prompt,
+        auth="codex-oauth",
+        provider="codex-oauth",
+        model="image_gen",
+        caller_skill=None,
+        endpoint="codex exec (image_gen)",
+        extra={"codex_thread_id": thread_id, "codex_events": event_count},
+    )
+    emit_progress(
+        "completed",
+        auth="codex-oauth",
+        ok=True,
+        terminal=True,
+        elapsed_ms=int((time.monotonic() - started) * 1000),
+        scillm_status="completed",
+        path=str(out),
+        receipt_path=str(receipt_file),
+        sha256=receipt["sha256"],
+        width=receipt["width"],
+        height=receipt["height"],
+        codex_events=event_count,
+    )
+    return receipt
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Default: Codex OAuth (codex login)\n"
+            "  python scripts/generate_image.py \\\n"
+            "    --prompt-file examples/image-prompts/sample-icon.prompt.md \\\n"
+            "    --out artifacts/images/sample-icon.png\n\n"
+            "  # CI / explicit API key path\n"
+            "  python scripts/generate_image.py --auth openai-api-key \\\n"
+            "    --prompt-file … --out … --caller-skill my-project\n"
+        ),
+    )
+    parser.add_argument("--prompt-file", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path)
+    parser.add_argument(
+        "--auth",
+        choices=["codex-oauth", "openai-api-key"],
+        default=os.getenv("SCILLM_IMAGE_AUTH", "codex-oauth"),
+    )
+    parser.add_argument("-C", "--cwd", type=Path, default=Path.cwd(), help="Workspace for codex exec")
+    parser.add_argument("--events-out", type=Path, help="Save codex JSONL when using codex-oauth")
+    parser.add_argument("--model", default=os.getenv("SCILLM_IMAGE_MODEL", DEFAULT_MODEL))
+    parser.add_argument("--quality", default=os.getenv("SCILLM_IMAGE_QUALITY", "high"))
+    parser.add_argument("--size", default=os.getenv("SCILLM_IMAGE_SIZE", "auto"))
+    parser.add_argument("--background", choices=["transparent", "opaque", "auto"])
+    parser.add_argument("--output-format", default="png", choices=["png", "jpeg", "webp"])
+    parser.add_argument("--base-url", default=os.getenv("SCILLM_BASE", os.getenv("PROXY_BASE", DEFAULT_BASE)))
+    parser.add_argument(
+        "--master-key",
+        default=os.getenv("MASTER_KEY", os.getenv("LITELLM_MASTER_KEY", "sk-dev-proxy-123")),
+    )
+    parser.add_argument("--caller-skill", default=os.getenv("X_CALLER_SKILL", "scillm-generate-image"))
+    parser.add_argument("--timeout-s", type=float, default=None)
+    parser.add_argument("--json", action="store_true", dest="json_out")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.auth == "codex-oauth":
+            receipt = generate_image_codex_oauth(
+                prompt_file=args.prompt_file,
+                out=args.out,
+                cwd=args.cwd,
+                receipt_path=args.receipt,
+                timeout_s=args.timeout_s,
+                events_out=args.events_out,
+            )
+        else:
+            receipt = generate_image_openai_api(
+                prompt_file=args.prompt_file,
+                out=args.out,
+                model=args.model,
+                quality=args.quality,
+                size=args.size,
+                background=args.background,
+                output_format=args.output_format,
+                base_url=args.base_url,
+                master_key=args.master_key,
+                caller_skill=args.caller_skill,
+                receipt_path=args.receipt,
+                timeout_s=args.timeout_s,
+            )
+    except (ValueError, RuntimeError, httpx.HTTPError) as exc:
+        emit_progress("failed", ok=False, terminal=True, error=str(exc))
+        print(f"generate_image: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json_out:
+        print(json.dumps(receipt, indent=2))
+    else:
+        print(
+            f"wrote {receipt['path']} ({receipt.get('width')}x{receipt.get('height')}, "
+            f"{receipt.get('bytes')} bytes) auth={receipt.get('auth')}"
+        )
+        print(f"receipt {receipt['receipt_path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_image.py
+++ b/scripts/generate_image.py
@@ -494,6 +494,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--caller-skill", default=os.getenv("X_CALLER_SKILL", "scillm-generate-image"))
     parser.add_argument("--timeout-s", type=float, default=None)
+    parser.add_argument(
+        "--first-event-timeout-s",
+        type=float,
+        default=float(os.getenv("SCILLM_IMAGE_FIRST_EVENT_TIMEOUT_S", "30")),
+        help="Maximum wait for the first Codex JSON event.",
+    )
     parser.add_argument("--json", action="store_true", dest="json_out")
     return parser
 
@@ -508,6 +514,7 @@ def main(argv: list[str] | None = None) -> int:
                 cwd=args.cwd,
                 receipt_path=args.receipt,
                 timeout_s=args.timeout_s,
+                first_event_s=args.first_event_timeout_s,
                 events_out=args.events_out,
             )
         else:

--- a/skills/scillm/SKILL.md
+++ b/skills/scillm/SKILL.md
@@ -1,53 +1,36 @@
 ---
 name: scillm
 description: >
-  Universal LLM proxy on localhost:4001. Surfaces: chat/batch completions,
-  scillm exec, OpenCode serve (coding delegate), OpenCode transport (DAG/SSE),
-  standing Codex agents. Chutes, Gemini, Claude/Codex OAuth, OpenCode Go, Ollama.
-  Auto-routes by model name. ZIP/PDF, JSON repair, batch pools.
+  Internal Tau-owned LLM proxy on localhost:4001. Maintainer surfaces:
+  one-shot chat, exec workers, and subagent delegates (OpenCode serve,
+  standing agents). Chutes, Gemini, Claude/Codex OAuth, OpenCode Go, Ollama.
+  ZIP/PDF, JSON repair.
 allowed-tools: Bash, Read
 triggers:
   - batch LLM calls
   - parallel completions
   - describe image
-  - describe figure
-  - describe table
-  - VLM call
+  - generate image
+  - image generation
+  - gpt-image-2
   - multimodal
-  - extract JSON from
-  - analyze image
   - LLM completion
-  - preflight check
-  - source grounding
-  - grounding verification
-  - verify grounded
   - call claude
   - call codex
-  - call gemini
-  - call glm
-  - call opencode go
+  - call kimi
+  - kimi exec
+  - scillm exec
   - opencode serve
   - opencode transport
-  - opencode agent
-  - scillm-debugger
   - standing agent
-  - scillm exec
-  - call deepseek v4
-  - call minimax
-  - send zip to LLM
-  - send PDF to LLM
+  - subagent
   - coding delegate
-  - patch agent
 metadata:
-  short-description: scillm (LLM proxy — chat, exec, OpenCode serve, transport, standing agents)
+  short-description: scillm (one-shot, exec, subagent — localhost:4001)
 provides:
   - llm-completion
 composes:
   - task-monitor
-  - create-evidence-case
-  - analytics
-  - create-figure
-  - llm-eval-lab
   - memory
   - dogpile
   - debugger
@@ -58,151 +41,516 @@ taxonomy:
 
 # scillm — One Endpoint for All LLM Calls
 
-**Human onboarding:** [README.md](README.md) (section index) · [project README](../../README.md) · **Repo contracts:** [docs/SCILLM_OPENCODE_SERVE.md](../../docs/SCILLM_OPENCODE_SERVE.md), [docs/SCILLM_OPENCODE_TRANSPORT_V1.md](../../docs/SCILLM_OPENCODE_TRANSPORT_V1.md), [docs/interactive-agents/](../../docs/interactive-agents/)
+> Project-agent boundary: SciLLM is now a Tau-owned provider sidecar. If a
+> project agent tries to call `$scillm`, `/scillm`, `http://localhost:4001`,
+> `/v1/chat/completions`, or `/v1/scillm/*` directly during ordinary project
+> work, stop and remind it to route provider/model work through a
+> `tau.dag_contract.v1` node, Tau skill node, or Tau-owned `command_spec`.
+> Direct SciLLM use is only for explicit SciLLM/Tau maintenance or Tau-authored
+> provider adapters that write receipts.
 
-## Critical Operating Rules
+**Repo:** [README.md](../../README.md) · **Deep refs:** [references/](references/) · **Contracts:** [docs/SCILLM_EXEC.md](../../docs/SCILLM_EXEC.md), [docs/SCILLM_OPENCODE_SERVE.md](../../docs/SCILLM_OPENCODE_SERVE.md)
 
-- **Batch calls:** `httpx.AsyncClient` + `asyncio.create_task` + `asyncio.as_completed(tasks)` unless the user explicitly requests `asyncio.gather` or strict input-order completion.
-- **No default gather** for `/scillm` batches. Reorder by `id` / `scillm_metadata` after completion if needed.
-- **Batch metadata:** Every batch item needs `scillm_metadata.batch_id` and `scillm_metadata.item_id`.
-- **Pick a surface first** (below). Wrong surface = wrong tool loop or missing artifacts.
+## Direct Maintainer Surfaces
 
-## Setup (one-time per provider)
+Direct calls are for Tau provider adapters and SciLLM maintainers only. Every
+direct scillm call uses the same host and headers:
 
-| Provider | Setup | Model / surface |
-|----------|-------|-----------------|
-| **Claude** | None if using Claude Code (`~/.claude/.credentials.json`) | `claude-sonnet-4-6`, `claude-haiku-4-5` |
-| **Codex** | `npm install -g @openai/codex && codex login` | `gpt-5.5` |
-| **Gemini** | `GEMINI_API_KEY` in `.env` | `gemini-2.5-flash`, `text-gemini` |
-| **GLM** | `GLM_API_Key` in `.env` | `text-glm` |
-| **Chutes** | `CHUTES_API_KEY` + `CHUTES_API_BASE` | `chutes-deepseek`, `Org/Model` |
-| **DeepSeek** | `DEEPSEEK_API` in `.env` | `text-deepseek` |
-| **OpenCode Go** | `OPENCODE_GO_API_KEY` in `.env` | `opencode-go/deepseek-v4-pro`, … |
-| **OpenCode serve** | `SCILLM_OPENCODE_SERVE_ENABLED=1`; `OPENCODE_SERVER_PASSWORD` when starting serve | `POST /v1/scillm/opencode/runs` — **agent profiles**, not chat models |
-| **Ollama** | `ollama pull model:tag` | Any `model:tag` |
+| Requirement | Value |
+|-------------|-------|
+| Base URL | `http://localhost:4001` |
+| Auth | `Authorization: Bearer sk-dev-proxy-123` (or your proxy key) |
+| Attribution | **`X-Caller-Skill: <your-project>`** — **required** on chat; use on all surfaces |
 
-Rebuild: `docker compose -p scillm -f deploy/docker/compose.scillm.core.yml up -d --build`
+**Pick exactly one call type:**
 
-**Auth:** `GET /v1/scillm/auth` with `Authorization: Bearer sk-dev-proxy-123`
+```text
+What do you need?
+│
+├─ 1. ONE-SHOT     → answer from a model (text, JSON, VLM describe)
+│                    POST /v1/chat/completions
+│
+├─ 1b. IMAGE       → create PNG from prompt file (NOT chat)
+│                    run.sh generate-image  OR  POST /v1/images/generations
+│                    Terminal: scillm.image.completed (stderr) or body.scillm.terminal
+│
+├─ 2. EXEC         → one bounded headless worker shot (DAG gate, no merge loop)
+│                    POST /v1/scillm/exec
+│
+└─ 3. SUBAGENT     → delegate repo work to a worker with tools
+       ├─ bounded session (read/grep/patch once)  → POST /v1/scillm/opencode/runs
+       └─ multi-turn standing worker (lease/turn)  → /v1/scillm/agents/*
+```
 
-## Invocation surfaces (pick one)
+| Call type | Endpoint | Returns | Use when |
+|-----------|----------|---------|----------|
+| **One-shot** | `POST /v1/chat/completions` | One completion JSON | Question, extraction, classify, describe image |
+| **Image create** | `run.sh generate-image` or `POST /v1/images/generations` | PNG + receipt; `scillm.terminal` | Generate icons, mockups, assets — never use chat for this |
+| **Exec** | `POST /v1/scillm/exec` | Worker receipt / stdout JSON | Pipeline gate, one CLI shot, graph node |
+| **Subagent (serve)** | `POST /v1/scillm/opencode/runs` | `assistant_text`, events, optional diff | Agent investigates/edits repo with skills/tools |
+| **Subagent (standing)** | `/v1/scillm/agents/*` | Turn result across leases | Same Codex worker across multiple turns |
 
-| Need | Use | Do **not** use |
-|------|-----|----------------|
-| One-shot text/VLM | `POST /v1/chat/completions` | OpenCode serve for a paragraph |
-| Pipeline gate / one headless CLI shot | `scillm exec` / `POST /v1/scillm/exec` | Product code authorship loops |
-| Bounded repo investigate + optional patch | **`POST /v1/scillm/opencode/runs`** | Chat with `opencode-go/*` in a loop |
-| DAG / debugger + SSE steer | **`POST /v1/scillm/opencode/transport/*`** | Blocking serve HTTP with no event tail |
-| Multi-turn Codex in worktree | `/v1/scillm/agents/*` | OpenCode serve for standing lease loops |
+**Do not mix these up:**
+- Chat `model` names (`gpt-5.5`, `moonshot-text`, `opencode-go/*`) → **one-shot only**
+- Exec `profile` names (`codex-gpt-5.5`, `kimi-k2.6`, `pi-chutes-kimi`) → **exec only**
+- OpenCode `agent` profiles (`build`, `scillm-debugger`) → **subagent serve only**
+- Never call Moonshot/Chutes/Gemini APIs directly — always `localhost:4001`
 
-### Why OpenCode serve sits between chat and exec
+## Reliable Chutes Calls Via `scillm-agent`
 
-- **Chat** — one completion; no `read`/`grep`/`skill` loop.
-- **Exec** — one bounded headless shot (`codex exec`, Pi, `opencode run` with skills/shell denied in config); for graph **gates**, not collaborative patching.
-- **OpenCode serve** — bounded OpenCode session with an **agent profile** + optional `skills[]`. The **project agent** owns memory, validation, and **merge**; the worker returns **evidence** (`assistant_text`, `events.jsonl`, optional `diff`) — not auto-merged.
-- **Standing agents** — multi-turn Codex with lease/handoff; see [references/standing-agents.md](references/standing-agents.md).
+Use `scillm-agent` as the protected control surface when a Tau provider adapter
+or SciLLM maintainer needs reliable Chutes single calls, batch calls, model
+choice, cold-model handling, dynamic concurrency, prompt preflight, or repair
+receipts. Chutes chat aliases are disabled; pass an exact live `Org/Model` ID
+selected with `ops-chutes`.
 
-Details: [references/opencode-serve.md](references/opencode-serve.md) · Repo: [docs/SCILLM_OPENCODE_SERVE.md](../../docs/SCILLM_OPENCODE_SERVE.md)
+```bash
+curl -sS http://localhost:4001/v1/scillm/chutes/completions \
+  -H "Authorization: Bearer sk-dev-proxy-123" \
+  -H "X-Caller-Skill: scillm-agent" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3.6-27B-TEE",
+    "messages": [{"role": "user", "content": "Tell me a story."}],
+    "stream": false
+  }'
+```
 
-Transport (DAG): [references/opencode-transport.md](references/opencode-transport.md) · [docs/SCILLM_OPENCODE_TRANSPORT_V1.md](../../docs/SCILLM_OPENCODE_TRANSPORT_V1.md)
+Before reliability-sensitive calls, check `ops-chutes model-health <model>` and
+`ops-chutes recommend <model> --json`. Do not hard-code Chutes fallback chains:
+inventory changes frequently, especially for batches. If no live comparable
+model exists, fail before launching a large batch with a structured error.
 
-Exec profiles: [references/exec-workers.md](references/exec-workers.md) · [docs/SCILLM_EXEC.md](../../docs/SCILLM_EXEC.md)
+Do not use `chutes-deepseek`, `chutes-qwen`, `chutes-kimi`, `vlm-chutes`, or
+`gpt-chutes` for Chutes chat calls.
 
-## How to call
+Golden proof:
 
-**Chat (default):** `POST http://localhost:4001/v1/chat/completions` — OpenAI format. Auth: `Bearer sk-dev-proxy-123`, `X-Caller-Skill: <project>`.
+```bash
+bash scripts/prove_chutes_golden_curl.sh \
+  --model 'Qwen/Qwen3.6-27B-TEE' \
+  --batch-size 2 \
+  --concurrency 2 \
+  --wall-time-s 180 \
+  --prompt 'Tell me a 100 word story.'
+```
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /v1/scillm/chutes/models` | List available Chutes models |
+| `POST /v1/scillm/chutes/completions` | Single completion (stream or non-stream) |
+| `POST /v1/scillm/chutes/batch` | Batch with semaphore + exponential backoff + `asyncio.as_completed` (SSE stream) |
+
+**`POST /v1/scillm/chutes/batch`** yields SSE events as items complete (not in input order):
+
+```bash
+curl -s -N --no-buffer http://localhost:4001/v1/scillm/chutes/batch \
+  -H "Authorization: Bearer sk-dev-proxy-123" \
+  -H "X-Caller-Skill: scillm-agent" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "requests": [
+      {"item_id":"item-0","model":"Qwen/Qwen3.6-27B-TEE","messages":[{"role":"user","content":"Say OK"}]},
+      {"item_id":"item-1","model":"Qwen/Qwen3.6-27B-TEE","messages":[{"role":"user","content":"Say hi"}]}
+    ],
+    "concurrency": 4
+  }'
+```
+
+Each event: `{"index": 0, "ok": true, "content": "...", "model_served": "...", "attempts": 1, "elapsed_s": 1.23}`
+
+From Python (asyncio):
+
+```python
+import asyncio
+import httpx
+import json
+
+async def chutes_batch(requests: list[dict], concurrency: int = 4):
+    url = "http://localhost:4001/v1/scillm/chutes/batch"
+    headers = {"Authorization": "Bearer sk-dev-proxy-123", "Content-Type": "application/json"}
+    body = {"requests": requests, "concurrency": concurrency}
+    async with httpx.AsyncClient(timeout=600.0) as client:
+        async with client.stream("POST", url, json=body, headers=headers) as resp:
+            async for line in resp.aiter_lines():
+                line = line.strip()
+                if line.startswith("data: "):
+                    yield json.loads(line[6:])
+
+async def main():
+    items = [
+        {"item_id": "item-0", "model": "Qwen/Qwen3.6-27B-TEE", "messages": [{"role": "user", "content": "Say OK"}]},
+        {"item_id": "item-1", "model": "Qwen/Qwen3.6-27B-TEE", "messages": [{"role": "user", "content": "Say hi"}]},
+    ]
+    async for result in chutes_batch(items):
+        status = "OK" if result["ok"] else f"FAIL ({result.get('error')})"
+        print(f"[{result['index']}] {status} — {result.get('content', '')[:60]}")
+
+asyncio.run(main())
+```
+
+Results arrive in **completion order** (fastest first). Use `result["index"]` to map back to the original request.
+
+**Architecture:**
+- Semaphore held only during the HTTP call (not during backoff sleep), so retrying one item doesn't block concurrent items
+- httpx.AsyncClient directly to `POST https://llm.chutes.ai/v1/chat/completions` (no OpenAI SDK)
+- Exponential backoff on 5xx/429/timeout; wall-time budget kills the retry loop
+- `X-Caller-Skill` is recommended for attribution; use `scillm-agent` for Chutes reliability lanes
+
+---
+
+### 1. One-shot (chat completions)
+
+**When:** You want one model response. No repo tool loop. No worker receipt.
 
 ```bash
 curl -s http://localhost:4001/v1/chat/completions \
   -H "Authorization: Bearer sk-dev-proxy-123" \
   -H "X-Caller-Skill: my-project" \
   -H "Content-Type: application/json" \
-  -d '{"model":"chutes-deepseek","messages":[{"role":"user","content":"What is 2+2?"}]}'
+  -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"What is 2+2?"}]}'
 ```
 
-**OpenCode serve (multi-step coding delegate):**
+**Common models:**
+
+| Intent | Model |
+|--------|-------|
+| General text | `gpt-5.5`, `claude-sonnet-4-6`, `gemini-flash`; for Chutes, exact live `Org/Model` from `ops-chutes` |
+| Image / PDF (pick provider) | `gpt-5.5`, `claude-sonnet-4-6`; for Chutes VLM, exact live `Org/Model` from `ops-chutes` |
+| Kimi text (Moonshot API) | `moonshot-text` |
+| Kimi + image (Moonshot API) | `moonshot-text` + OpenAI `image_url` parts |
+| Kimi via OpenCode Go | `oc-kimi` or `opencode-go/kimi-k2.6` |
+
+**Kimi rules (one-shot):**
+- `moonshot-text` → native Moonshot `kimi-k2.6`; supports PNG/JPEG via `image_url`
+- `kimi_exec` is **not** one-shot — it is **exec** (text only, no images)
+- Do **not** use generic `vlm` when you want Kimi — that is Gemini → Claude → Codex
+- Avoid legacy alias `text` when provider choice matters
+
+**Image example (Moonshot Kimi):**
+
+```bash
+curl -s http://localhost:4001/v1/chat/completions \
+  -H "Authorization: Bearer sk-dev-proxy-123" \
+  -H "X-Caller-Skill: my-project" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "moonshot-text",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What color is this image? One word."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,<BASE64>"}}
+      ]
+    }]
+  }'
+```
+
+**Slash shortcut:** `/scillm "…"` · `/scillm --model moonshot-text "Describe @screenshot.png"`
+
+
+### 1b. Image generation (create images) — **maintainer path**
+
+**`/scillm` slash wrapper — image vs chat (critical):**
+
+| Task | Command | Termination signal |
+|------|---------|-------------------|
+| Text / VLM describe | `run.sh "…"` or `run.sh --model gpt-5.5 "…"` | Chat completion text on stdout |
+| **Generate image (GPT)** | `run.sh generate-image --prompt-file … --out … --auth openai-api-key` | stderr NDJSON `scillm.image.completed` + exit 0 + receipt JSON |
+| Generate image (OAuth) | `run.sh generate-image --prompt-file … --out …` (default `--auth codex-oauth`) | stderr `scillm.image.completed` after codex JSONL |
+
+**Never** use plain `run.sh "generate a PNG…"` for image creation — that only calls `/v1/chat/completions` and finishes with **text**, not a PNG.
+
+Progress events (stderr, one JSON object per line):
+
+```jsonl
+{"type":"scillm.image.started","auth":"openai-api-key","model":"gpt-image-2","prompt_chars":582}
+{"type":"scillm.image.completed","auth":"openai-api-key","ok":true,"terminal":true,"elapsed_ms":14200,"path":"artifacts/images/x.png","receipt_path":"artifacts/images/x_receipt.json","sha256":"…","width":1024,"height":1024}
+```
+
+HTTP `POST /v1/images/generations` also returns a terminal envelope:
+
+```json
+"scillm": {"status": "completed", "terminal": true, "elapsed_ms": 14200, "caller_skill": "…", "has_b64": true}
+```
+
+CLI: `scillm image generate --prompt-file … --out … --auth openai-api-key`
+
+
+
+**When:** Generate a **new** image from a large/detailed spec (mockups, icons, scenes, UI assets).
+
+## Auth model (read this first)
+
+| Auth | How | Use when |
+|------|-----|----------|
+| **`codex-oauth` (DEFAULT)** | `codex login` (ChatGPT subscription) + built-in **`image_gen`** via `codex exec` | Tau/SciLLM maintenance — no `OPENAI_API_KEY` |
+| **`openai-api-key` (opt-in)** | `POST /v1/images/generations` on scillm with `OPENAI_API_KEY` on proxy host | CI, headless servers without Codex, explicit API billing |
+
+**Critical:** Codex OAuth tokens **cannot** call `https://api.openai.com/v1/images/generations` (401: missing `api.model.images.request` scope). Do not point OAuth at the HTTP images endpoint.
+
+**Do not use** bare `$imagegen` / agent-only flows without the wrapper — they save under `~/.codex/generated_images/` and skip receipts.
+
+## Canonical workflow (DEFAULT: Codex OAuth)
+
+1. **Ensure auth:** `codex login status` → logged in via ChatGPT.
+
+2. **Write prompt file** in repo (structured sections; up to **32,000 chars**):
+
+   Template: `examples/image-prompts/sample-icon.prompt.md` (`SUBJECT`, `COMPOSITION`, `STYLE`, `MUST INCLUDE`, `MUST NOT INCLUDE`, `OUTPUT`).
+
+3. **Run receipt wrapper** (monitors codex JSONL; copies PNG + writes receipt):
+
+```bash
+bash skills/scillm/run.sh generate-image \
+  --auth openai-api-key \
+  --prompt-file path/to/your.prompt.md \
+  --out artifacts/images/your-asset.png \
+  --model gpt-image-2 \
+  --quality high
+
+# equivalent:
+python scripts/generate_image.py --auth openai-api-key ...
+```
+
+`--auth codex-oauth` is the default; `--caller-skill` is not required on this path.
+
+4. **Pass/fail gate:**
+
+   - exit code `0`
+   - `--out` PNG exists (`bytes > 0`)
+   - receipt JSON (`<stem>_receipt.json` or `--receipt`) has `ok: true`, `auth: "codex-oauth"`, `sha256`, `width`, `height`
+   - codex JSONL shows `thread.started` within ~30s (script fails fast if silent)
+
+## Opt-in workflow: OpenAI API key (HTTP)
+
+Use only when Codex OAuth is unavailable or you explicitly want direct API billing.
+
+```bash
+python scripts/generate_image.py \
+  --auth openai-api-key \
+  --prompt-file path/to/your.prompt.md \
+  --out artifacts/images/your-asset.png \
+  --caller-skill your-project \
+  --model gpt-image-2 \
+  --quality high \
+  --size 1536x1024
+```
+
+Requires `OPENAI_API_KEY` on the **scillm proxy host**. Requires `X-Caller-Skill` (via `--caller-skill`).
+
+Direct HTTP equivalent:
+
+```bash
+curl -s http://localhost:4001/v1/images/generations \
+  -H "Authorization: Bearer sk-dev-proxy-123" \
+  -H "X-Caller-Skill: my-project" \
+  -H "Content-Type: application/json" \
+  -d @request.json
+```
+
+`request.json` → `model: gpt-image-2`, `quality: high`, `prompt` (max 32k chars), `response_format: b64_json`.
+
+| Intent | Model | Auth on proxy |
+|--------|-------|----------------|
+| Best quality / detailed spec | `gpt-image-2` | `OPENAI_API_KEY` |
+| Transparent PNG | `gpt-image-1.5` + `background=transparent` | `OPENAI_API_KEY` |
+| Cheap draft | `gpt-image-1-mini` | `OPENAI_API_KEY` |
+| Fast/free | `z-image-turbo` | `CHUTES_API_KEY` |
+
+Batch (API-key path): `POST /v1/scillm/batch/images/generations` with `items[]`.
+
+Discover: `GET /v1/scillm/capabilities` → `image_generation`.
+
+## Not image generation
+
+| Surface | What it does |
+|---------|----------------|
+| `gpt-5.5` on `/v1/chat/completions` | Chat + vision **in** (describe existing images) |
+| Codex `$imagegen` without wrapper | OAuth yes, but **no** guaranteed workspace path/receipt |
+| `codex exec` without `generate_image.py` | You must monitor JSONL + copy files yourself |
+
+Prompt > 32k chars: compress to a brief (one-shot chat) before image generation.
+
+More: [references/chat-calls.md](references/chat-calls.md) · [references/files-multimodal.md](references/files-multimodal.md)
+
+---
+
+### 2. Exec (bounded worker shot)
+
+**When:** A pipeline or DAG needs **one** headless worker attempt — classify, gate, diagnose — without you merging a multi-step agent session.
+
+**Not for:** Open-ended product implementation loops (use subagent serve). Not for ordinary Q&A (use one-shot).
+
+```bash
+curl -s -X POST http://localhost:4001/v1/scillm/exec \
+  -H "Authorization: Bearer sk-dev-proxy-123" \
+  -H "X-Caller-Skill: my-project" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "kimi_exec",
+    "model": "kimi-k2.6",
+    "prompt": "What is 2+2? Reply with the digit 4 only.",
+    "metadata": {"sandbox": "read-only"}
+  }'
+```
+
+**Common exec profiles:**
+
+| Profile | Worker | Notes |
+|---------|--------|-------|
+| `codex-gpt-5.5` | Codex CLI | Bounded `codex exec` — not chat `gpt-5.5` |
+| `kimi-k2.6` / `kimi` | Kimi CLI (`kimi -p`) | **Text only** — no image API |
+| `pi-chutes-kimi` | Pi over Chutes Kimi | Low-overhead exec lane |
+| `oc-chutes-deepseek` | OpenCode CLI one-shot | Skills denied in generated config |
+
+**Rules:**
+- Pass **profile names** (`kimi-k2.6`), not chat aliases (`oc-kimi`, `moonshot-text`, `opencode-go/*`)
+- `kimi_exec` needs Kimi CLI auth in the proxy container (`~/.kimi`, `KIMI_API_KEY`)
+- Exec returns evidence for the graph — **you** validate and decide next step
+
+More: [references/exec-workers.md](references/exec-workers.md) · [docs/SCILLM_EXEC.md](../../docs/SCILLM_EXEC.md)
+
+---
+
+### 3. Subagent (delegated workers)
+
+**When:** You delegate repo work to a worker that can **read, grep, use skills, and optionally patch**. You own validation and merge.
+
+#### 3a. OpenCode serve — bounded session (most common)
+
+**When:** One investigation or patch attempt with tools. Single session, then done.
 
 ```bash
 curl -s -X POST http://localhost:4001/v1/scillm/opencode/runs \
   -H "Authorization: Bearer sk-dev-proxy-123" \
   -H "X-Caller-Skill: my-project" \
   -H "Content-Type: application/json" \
-  -d '{"prompt":"Inspect tests/test_foo.py; do not edit.","agent":"build","skills":["memory","scillm"],"timeout_s":600}'
+  -d '{
+    "prompt": "Read tests/test_foo.py and explain the failure. Do not edit.",
+    "agent": "build",
+    "skills": ["memory", "debugger", "scillm"],
+    "timeout_s": 600
+  }'
 ```
 
-Never put `opencode-go/kimi-k2.6` in `"agent"` — that is a **chat model**. Never call raw `http://127.0.0.1:4096` from product code.
+| Field | Rule |
+|-------|------|
+| `agent` | OpenCode **profile** (`build`, `scillm-debugger`) — from `GET /v1/scillm/opencode/agents` |
+| `skills` | Optional allowlist (`memory`, `dogpile`, `debugger`, `scillm`, …) |
+| `prompt` | Your task — paste `/memory` recall and `/dogpile` synthesis here first |
 
-**Verify serve:** `bash scripts/sanity_opencode_serve.sh` (from scillm repo root).
+**Wrong:** `"agent": "opencode-go/kimi-k2.6"` — that is a **chat model**, not an agent profile.
 
-**Slash wrapper:** `/scillm "…"` · `/scillm --model moonshot-text "…"`
+**Wrong:** `POST /v1/chat/completions` in a loop to "fix the bug" — no tool loop, no artifacts.
 
-## Project-agent workflow (OpenCode serve)
+Enable: `SCILLM_OPENCODE_SERVE_ENABLED=1`. Verify: `bash scripts/sanity_opencode_serve.sh`
 
-OpenCode serve does **not** replace `/memory`, `/dogpile`, `/debugger`, or chat `/scillm`.
+More: [references/opencode-serve.md](references/opencode-serve.md)
+
+#### 3b. Standing agents — multi-turn Codex worker
+
+**When:** Same worker across multiple turns with lease/handoff (reviewer, implementation worker).
 
 ```text
-1. /memory recall --brief --q "<task>"
-2. /dogpile … (if novel/ambiguous) → paste into prompt
-3. /debugger (if stuck or hidden runtime state) → breakpoint proof before patch
-4. POST /v1/scillm/opencode/runs  → optional skills: ["memory","debugger","scillm",…]
-5. Validate artifacts; project agent merges or fork-retries
-6. /memory store lesson (after verified fix)
+GET  /v1/scillm/agents/registry
+POST /v1/scillm/agents/{worker_id}/handoffs
+POST /v1/scillm/agents/{worker_id}/leases
+POST /v1/scillm/agents/{worker_id}/turn
+GET  /v1/scillm/agents/{worker_id}/result?handoff_id=...
+POST /v1/scillm/agents/{worker_id}/cleanup
 ```
 
-| Skill | Who runs | Connection |
-|-------|----------|------------|
-| `/memory` | Project agent (+ optional `skills[]`) | Ground `prompt`; store after success |
-| `/dogpile` | Project agent first | Paste synthesis into `prompt` |
-| `/debugger` | Project agent when stuck | Proof before asking serve to patch |
-| `/scillm` | Project or OpenCode via skill | Sidecar `localhost:4001` only |
+Prerequisite: worker registered in `config/scillm-agents.yaml`. Proof: `bash scripts/sanity_agents_endpoints.sh`
 
-## Models and routing (summary)
+More: [references/standing-agents.md](references/standing-agents.md)
 
-Use model names directly (`claude-*`, `gpt-*`, `gemini-*`, `opencode-go/*`, `Org/Model`, `model:tag`). Discover: `GET /v1/scillm/providers`, `GET /v1/scillm/opencode-go/models?refresh=true`.
+#### 3c. Transport / harness (advanced)
 
-Avoid deprecated broad alias `text` for QRA/corpus repair. For quota-sensitive VLM prefer `gpt-5.5` or `vlm-chutes` over generic `vlm`.
+**When:** DAG parent/child runs, SSE steering, execution harness loops — not everyday project-agent calls.
 
-Full tables, Chutes cold-start, OpenCode Go caveats: [references/models-and-routing.md](references/models-and-routing.md)
+More: [references/opencode-transport.md](references/opencode-transport.md) · [docs/SCILLM_OPENCODE_TRANSPORT_V1.md](../../docs/SCILLM_OPENCODE_TRANSPORT_V1.md)
 
-## Reference map (load on demand)
+---
+
+## Quick comparison (copy this)
+
+| You want… | Call type | Example |
+|-----------|-----------|---------|
+| "What is 2+2?" | One-shot | `POST /v1/chat/completions` `model: gpt-5.5`; for Chutes, exact live `Org/Model` |
+| Chutes single call | Direct Chutes | `POST /v1/scillm/chutes/completions` `model: Qwen/Qwen3.6-27B-TEE` |
+| Batch Chutes — semaphore + retry + as_completed | Direct Chutes batch | `POST /v1/scillm/chutes/batch` with exact live `Org/Model` IDs |
+| "Describe this PNG" (Kimi) | One-shot | `model: moonshot-text` + `image_url` |
+| "Generate a PNG/icon/mockup from detailed spec" | **Image (OAuth default)** | `python scripts/generate_image.py --prompt-file … --out …` (`codex login`) |
+| DAG gate: classify this text | Exec | `POST /v1/scillm/exec` `type: kimi_exec` |
+| "Fix the failing test" | Subagent serve | `POST /v1/scillm/opencode/runs` `agent: build` |
+| Reviewer across 3 turns | Subagent standing | `/v1/scillm/agents/{worker}/turn` |
+
+---
+
+## Setup (one-time)
+
+| Provider | Env / auth | One-shot model examples |
+|----------|------------|-------------------------|
+| Claude | `~/.claude/.credentials.json` | `claude-sonnet-4-6` |
+| Codex | `codex login` | `gpt-5.5` |
+| Gemini | `GEMINI_API_KEY` | `text-gemini`, `gemini-2.5-flash` |
+| Moonshot Kimi | `MOONSHOT_API_KEY` | `moonshot-text` |
+| Kimi CLI (exec only) | `KIMI_API_KEY` + `kimi-cli` | exec profile `kimi-k2.6` |
+| OpenCode Go | `OPENCODE_GO_API_KEY` | `oc-kimi`, `opencode-go/deepseek-v4-pro` |
+| Chutes | `CHUTES_API_KEY` | Exact live `Org/Model` selected with `ops-chutes` |
+| OpenCode serve | `SCILLM_OPENCODE_SERVE_ENABLED=1` | subagent `agent: build` |
+| Ollama | `ollama pull model:tag` | `qwen2.5:7b` |
+
+Rebuild: `docker compose -p scillm -f deploy/docker/compose.scillm.core.yml up -d --build`
+
+Check auth: `GET /v1/scillm/auth` · Discover models: `GET /v1/scillm/providers`
+
+---
+
+## Critical operating rules
+
+- **Pick the call type first** — one-shot vs exec vs subagent. Wrong surface = wrong artifacts.
+- **`X-Caller-Skill` is required** on chat completions (400 if missing).
+- **Batch calls:** `httpx.AsyncClient` + `asyncio.create_task` + `asyncio.as_completed` — not default `gather`. Each item needs `scillm_metadata.batch_id` and `item_id`.
+- **Subagent output is evidence** — validate receipts/diffs before merge. Executors do not own truth.
+- **Orchestrator / harness** — only for multi-step delegated runs with DAG state. See [references/opencode-transport.md](references/opencode-transport.md). Not for rename-one-function work.
+
+---
+
+## Reference map
 
 | Topic | File |
 |-------|------|
-| Chat, JSON, VLM, message shapes | [references/chat-calls.md](references/chat-calls.md) |
-| Batch, pools, `as_completed`, OpenCode Go batches | [references/batch-calls.md](references/batch-calls.md) |
-| Source grounding | [references/grounding-and-hedged.md](references/grounding-and-hedged.md) |
-| ZIP/PDF/images/files | [references/files-multimodal.md](references/files-multimodal.md) |
-| Claude / Codex OAuth | [references/oauth-claude-codex.md](references/oauth-claude-codex.md) |
-| `scillm exec` profiles | [references/exec-workers.md](references/exec-workers.md) |
-| OpenCode serve parameters, fork, skills | [references/opencode-serve.md](references/opencode-serve.md) |
-| OpenCode transport SSE | [references/opencode-transport.md](references/opencode-transport.md) |
-| Standing `/v1/scillm/agents/*` | [references/standing-agents.md](references/standing-agents.md) |
-| Middleware, cascade, retry, cache | [references/proxy-internals.md](references/proxy-internals.md) |
+| Chat, JSON, message shapes | [references/chat-calls.md](references/chat-calls.md) |
+| Images, PDF, ZIP | [references/files-multimodal.md](references/files-multimodal.md) |
+| Model routing tables | [references/models-and-routing.md](references/models-and-routing.md) |
+| Exec profiles | [references/exec-workers.md](references/exec-workers.md) |
+| OpenCode serve | [references/opencode-serve.md](references/opencode-serve.md) |
+| Standing agents | [references/standing-agents.md](references/standing-agents.md) |
+| Transport / harness | [references/opencode-transport.md](references/opencode-transport.md) |
+| Batch / pools | [references/batch-calls.md](references/batch-calls.md) |
 | Ops endpoints | [references/ops-endpoints.md](references/ops-endpoints.md) |
-| Paved path contract | [docs/SCILLM_PAVED_PATH_CONTRACT.md](docs/SCILLM_PAVED_PATH_CONTRACT.md) |
+
+Specialized lanes (load only when needed): pdf-lab → [docs/SCILLM_PDF_LAB_OPENCODE_SERVE_HARDENING_PLAN.md](../../docs/SCILLM_PDF_LAB_OPENCODE_SERVE_HARDENING_PLAN.md)
+
+---
 
 ## Ops (quick)
 
 | Endpoint | Purpose |
 |----------|---------|
 | `GET /health/liveliness` | Proxy alive |
-| `GET /v1/scillm/health` | Groups, fallbacks, concurrency |
-| `GET /v1/scillm/auth` | OAuth token health |
-| `POST /v1/scillm/batch/completions` | Server-side `model_pool` batches |
-| `POST /v1/scillm/opencode/runs` | OpenCode serve run |
-| `POST /v1/scillm/opencode/transport/runs` | Transport run |
+| `GET /v1/scillm/health` | Groups, fallbacks |
+| `GET /v1/scillm/auth` | OAuth / key health |
+| `POST /v1/scillm/batch/completions` | Server-side batch |
+| `POST /v1/scillm/opencode/runs` | Subagent serve |
 | `GET /v1/scillm/agents/registry` | Standing workers |
+| `GET /v1/scillm/chutes/models` | List available Chutes models |
+| `POST /v1/scillm/chutes/completions` | Direct Chutes (no middleware) |
+| `POST /v1/scillm/chutes/batch` | Direct Chutes batch (SSE as_completed) |
 
-Full table: [references/ops-endpoints.md](references/ops-endpoints.md)
-
-## Composable skills
-
-| Skill | Integration |
-|-------|-------------|
-| `/memory` | Recall before work; optional `"memory"` in OpenCode `skills[]` |
-| `/dogpile` | Research before hard problems; optional `"dogpile"` in `skills[]` |
-| `/debugger` | Breakpoint proof before patch; `/opencode/serve/debugger/run` |
-| `/task-monitor` | Long-run monitoring |
-| `/create-evidence-case`, `/analytics`, `/create-figure`, `/llm-eval-lab` | Chat completions |
-
-All composable skills call **`http://localhost:4001`** — no direct provider APIs.
+Composable skills must not instruct project agents to call
+**`http://localhost:4001`** directly. If a provider/model call is needed, route
+it through Tau or keep it inside the skill's owned runtime with explicit proof
+boundaries.

--- a/src/scillm/proxy/providers/auth.py
+++ b/src/scillm/proxy/providers/auth.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,9 @@ ANTHROPIC_EXPIRY_BUFFER_MS = 5 * 60 * 1000  # 5-minute safety margin
 # OpenAI Codex OAuth
 CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_EXPIRY_BUFFER_S = 5 * 60  # refresh before JWT exp when possible
+
+_ANTHROPIC_REFRESH_CACHE: dict[str, Any] | None = None
 
 
 def _read_auth() -> dict[str, Any]:
@@ -110,6 +114,59 @@ def _refresh_codex(cred: dict[str, Any]) -> dict[str, Any] | None:
         return None
 
 
+def _cache_anthropic_refresh(new_cred: dict[str, Any]) -> None:
+    global _ANTHROPIC_REFRESH_CACHE
+    _ANTHROPIC_REFRESH_CACHE = dict(new_cred)
+
+
+def _anthropic_cached_token_valid(now_ms: int) -> str | None:
+    if not _ANTHROPIC_REFRESH_CACHE:
+        return None
+    access = _ANTHROPIC_REFRESH_CACHE.get("access")
+    expires = int(_ANTHROPIC_REFRESH_CACHE.get("expires") or 0)
+    if access and now_ms < expires:
+        logger.debug(
+            "Using cached Anthropic OAuth token refreshed by SciLLM (expires in {}s)",
+            (expires - now_ms) // 1000,
+        )
+        return str(access)
+    return None
+
+
+def _write_claude_code_credentials(new_cred: dict[str, Any]) -> None:
+    try:
+        data = json.loads(CLAUDE_CODE_CREDENTIALS.read_text())
+        data["claudeAiOauth"]["accessToken"] = new_cred["access"]
+        data["claudeAiOauth"]["refreshToken"] = new_cred["refresh"]
+        data["claudeAiOauth"]["expiresAt"] = new_cred["expires"]
+        CLAUDE_CODE_CREDENTIALS.write_text(json.dumps(data, indent=2))
+        logger.info("Updated Claude Code credentials after refresh")
+    except (json.JSONDecodeError, OSError, KeyError) as exc:
+        logger.warning(
+            "Could not update Claude Code credentials after Anthropic refresh; "
+            "using in-process refreshed token until restart: {}",
+            exc,
+        )
+
+
+def _refresh_claude_code_token(cc_creds: dict[str, Any]) -> str | None:
+    refresh_token = cc_creds.get("refreshToken")
+    access_token = cc_creds.get("accessToken")
+    if not refresh_token:
+        logger.error("Claude Code credentials missing refreshToken; run `claude auth login --claudeai`")
+        return None
+    new_cred = _refresh_anthropic({
+        "refresh": refresh_token,
+        "access": access_token,
+        "expires": cc_creds.get("expiresAt", 0),
+    })
+    if not new_cred:
+        return None
+    _cache_anthropic_refresh(new_cred)
+    _write_claude_code_credentials(new_cred)
+    return str(new_cred["access"])
+
+
 def _extract_codex_account_id(access_token: str) -> str | None:
     """Extract chatgpt_account_id from JWT payload."""
     import base64
@@ -124,6 +181,91 @@ def _extract_codex_account_id(access_token: str) -> str | None:
         return payload.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
     except Exception:
         return None
+
+
+
+
+def _jwt_exp_unix(access_token: str) -> int | None:
+    """Return JWT ``exp`` claim as unix seconds, if present."""
+    import base64
+
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (4 - len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        exp = payload.get("exp")
+        return int(exp) if exp is not None else None
+    except Exception:
+        return None
+
+
+def _write_codex_auth_file(data: dict[str, Any]) -> None:
+    """Persist Codex CLI auth.json (requires a writable bind mount in Docker)."""
+    try:
+        CODEX_AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CODEX_AUTH_FILE.write_text(json.dumps(data, indent=2))
+    except OSError as exc:
+        logger.warning("Could not write Codex auth.json: {}", exc)
+
+
+def _refresh_codex_cli_tokens(tokens: dict[str, Any]) -> dict[str, Any] | None:
+    """Refresh Codex CLI ``~/.codex/auth.json`` tokens using ``refresh_token``."""
+    refresh_token = tokens.get("refresh_token")
+    if not refresh_token:
+        logger.error("Codex auth.json missing refresh_token; run `codex login` on the host")
+        return None
+    try:
+        resp = httpx.post(
+            CODEX_TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CODEX_CLIENT_ID,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        access_token = data["access_token"]
+        account_id = (
+            tokens.get("account_id")
+            or _extract_codex_account_id(access_token)
+            or ""
+        )
+        new_tokens = {
+            "access_token": access_token,
+            "refresh_token": data.get("refresh_token", refresh_token),
+            "account_id": account_id,
+        }
+        if data.get("id_token"):
+            new_tokens["id_token"] = data["id_token"]
+        elif tokens.get("id_token"):
+            new_tokens["id_token"] = tokens["id_token"]
+
+        auth_doc = json.loads(CODEX_AUTH_FILE.read_text()) if CODEX_AUTH_FILE.exists() else {}
+        auth_doc["tokens"] = new_tokens
+        auth_doc["last_refresh"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        _write_codex_auth_file(auth_doc)
+        logger.info("Refreshed Codex CLI OAuth token (account={}...)", account_id[:8] if account_id else "?")
+        return new_tokens
+    except Exception as exc:
+        logger.error("Codex CLI token refresh failed: {}", exc)
+        return None
+
+
+def _ensure_codex_cli_tokens_fresh(tokens: dict[str, Any], *, force: bool = False) -> dict[str, Any] | None:
+    """Refresh Codex CLI tokens when JWT is near expiry or ``force`` is set."""
+    access = tokens.get("access_token")
+    if not access:
+        return None
+    exp = _jwt_exp_unix(access)
+    now = int(time.time())
+    if not force and exp is not None and now + CODEX_EXPIRY_BUFFER_S < exp:
+        return tokens
+    return _refresh_codex_cli_tokens(tokens)
 
 
 def _read_claude_code_credentials() -> dict[str, Any] | None:
@@ -141,39 +283,32 @@ def _read_claude_code_credentials() -> dict[str, Any] | None:
         return None
 
 
-def get_anthropic_token() -> str | None:
+def get_anthropic_token(*, force_refresh: bool = False) -> str | None:
     """Get a valid Anthropic OAuth access token.
 
     Priority: Claude Code credentials (~/.claude) > Pi auth (~/.pi/agent).
-    Auto-refreshes expired tokens.
+    Auto-refreshes expired tokens. Use ``force_refresh`` after a provider 401
+    because Anthropic can revoke an otherwise unexpired access token.
     """
+    now_ms = int(time.time() * 1000)
+    if not force_refresh:
+        cached = _anthropic_cached_token_valid(now_ms)
+        if cached:
+            return cached
+
     # Try Claude Code credentials first (always freshest — managed by the running CLI)
     cc_creds = _read_claude_code_credentials()
     if cc_creds:
-        now_ms = int(time.time() * 1000)
         expires = cc_creds.get("expiresAt", 0)
-        if now_ms < expires:
+        if not force_refresh and now_ms < expires:
             logger.debug("Using Claude Code OAuth token (expires in {}s)", (expires - now_ms) // 1000)
             return cc_creds["accessToken"]
-        # Claude Code token expired — try to refresh it
-        logger.info("Claude Code token expired, refreshing...")
-        new_cred = _refresh_anthropic({
-            "refresh": cc_creds["refreshToken"],
-            "access": cc_creds["accessToken"],
-            "expires": expires,
-        })
-        if new_cred:
-            # Write back to Claude Code credentials format
-            try:
-                data = json.loads(CLAUDE_CODE_CREDENTIALS.read_text())
-                data["claudeAiOauth"]["accessToken"] = new_cred["access"]
-                data["claudeAiOauth"]["refreshToken"] = new_cred["refresh"]
-                data["claudeAiOauth"]["expiresAt"] = new_cred["expires"]
-                CLAUDE_CODE_CREDENTIALS.write_text(json.dumps(data, indent=2))
-                logger.info("Updated Claude Code credentials after refresh")
-            except OSError as exc:
-                logger.warning("Could not update Claude Code credentials: {}", exc)
-            return new_cred["access"]
+        logger.info("Claude Code token {}refreshing...", "force-" if force_refresh else "expired, ")
+        refreshed = _refresh_claude_code_token(cc_creds)
+        if refreshed:
+            return refreshed
+        if force_refresh:
+            return None
 
     # Fall back to Pi auth.json
     auth_data = _read_auth()
@@ -181,11 +316,11 @@ def get_anthropic_token() -> str | None:
     if not cred or cred.get("type") != "oauth":
         return None
 
-    now_ms = int(time.time() * 1000)
-    if now_ms >= cred.get("expires", 0):
-        logger.info("Pi Anthropic token expired, refreshing...")
+    if force_refresh or now_ms >= cred.get("expires", 0):
+        logger.info("Pi Anthropic token {}refreshing...", "force-" if force_refresh else "expired, ")
         new_cred = _refresh_anthropic(cred)
         if new_cred:
+            _cache_anthropic_refresh(new_cred)
             auth_data["anthropic"] = new_cred
             _write_auth(auth_data)
             return new_cred["access"]
@@ -209,30 +344,29 @@ def _read_codex_auth() -> dict[str, Any] | None:
         return None
 
 
-def get_codex_credentials() -> tuple[str, str] | None:
+def get_codex_credentials(*, force_refresh: bool = False) -> tuple[str, str] | None:
     """Get (access_token, account_id) for Codex.
 
     Priority: Codex CLI auth (~/.codex) > Pi auth (~/.pi/agent).
-    Auto-refreshes expired tokens.
+    Auto-refreshes expired or near-expiry tokens; use ``force_refresh`` after 401.
     """
-    # Try Codex CLI credentials first (always freshest)
     codex_tokens = _read_codex_auth()
     if codex_tokens:
-        access = codex_tokens["access_token"]
-        account_id = codex_tokens.get("account_id") or _extract_codex_account_id(access) or ""
-        # Codex CLI manages its own refresh — we can try the token and let it fail
-        # if expired, then refresh ourselves
+        fresh = _ensure_codex_cli_tokens_fresh(codex_tokens, force=force_refresh)
+        if not fresh:
+            return None
+        access = fresh["access_token"]
+        account_id = fresh.get("account_id") or _extract_codex_account_id(access) or ""
         logger.debug("Using Codex CLI OAuth token (account={}...)", account_id[:8] if account_id else "?")
         return access, account_id
 
-    # Fall back to Pi auth.json
     auth_data = _read_auth()
     cred = auth_data.get("openai-codex")
     if not cred or cred.get("type") != "oauth":
         return None
 
     now_ms = int(time.time() * 1000)
-    if now_ms >= cred.get("expires", 0):
+    if force_refresh or now_ms >= cred.get("expires", 0):
         logger.info("Pi Codex token expired, refreshing...")
         new_cred = _refresh_codex(cred)
         if new_cred:
@@ -243,6 +377,48 @@ def get_codex_credentials() -> tuple[str, str] | None:
 
     account_id = cred.get("accountId") or _extract_codex_account_id(cred["access"]) or ""
     return cred["access"], account_id
+
+
+def inspect_codex_auth() -> dict[str, Any]:
+    """Summarize Codex OAuth health for /v1/scillm/auth (no secrets)."""
+    now = int(time.time())
+    codex_tokens = _read_codex_auth()
+    if codex_tokens:
+        access = codex_tokens.get("access_token", "")
+        exp = _jwt_exp_unix(access) if access else None
+        remaining_s = max(0, (exp - now)) if exp is not None else None
+        auth_doc: dict[str, Any] = {}
+        if CODEX_AUTH_FILE.exists():
+            try:
+                auth_doc = json.loads(CODEX_AUTH_FILE.read_text())
+            except (json.JSONDecodeError, OSError):
+                auth_doc = {}
+        status = "valid"
+        if not access:
+            status = "not_configured"
+        elif exp is not None and now >= exp:
+            status = "expired"
+        return {
+            "status": status,
+            "source": str(CODEX_AUTH_FILE),
+            "account_id": (codex_tokens.get("account_id") or "")[:12] + "...",
+            "expires_in_s": remaining_s,
+            "last_refresh": auth_doc.get("last_refresh"),
+            "refresh_available": bool(codex_tokens.get("refresh_token")),
+        }
+
+    auth_data = _read_auth()
+    cred = auth_data.get("openai-codex", {})
+    if cred.get("type") == "oauth":
+        expires_ms = cred.get("expires", 0)
+        remaining_s = max(0, (expires_ms - int(time.time() * 1000)) // 1000)
+        return {
+            "status": "valid" if int(time.time() * 1000) < expires_ms else "expired",
+            "source": str(AUTH_FILE),
+            "expires_in_s": remaining_s,
+            "refresh_available": bool(cred.get("refresh")),
+        }
+    return {"status": "not_configured"}
 
 
 def is_anthropic_available() -> bool:

--- a/src/scillm/proxy/providers/claude.py
+++ b/src/scillm/proxy/providers/claude.py
@@ -15,6 +15,7 @@ import httpx
 import openai
 from loguru import logger
 
+from scillm.proxy.errors import ProviderOAuthError, provider_error_code_for_status
 from scillm.proxy.providers import make_chunk_id, sse_chunk, sse_done, sse_format, streaming_timeout
 from scillm.proxy.providers.auth import get_anthropic_token
 
@@ -41,6 +42,71 @@ CLAUDE_MODEL_MAP = {
     "claude-haiku-4-5": "claude-haiku-4-5-20251001",
     "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
 }
+
+_CLAUDE_THINKING_BUDGET_TOKENS = {
+    "low": 1024,
+    "medium": 4096,
+    "high": 8192,
+    "xhigh": 16384,
+    "max": 32000,
+}
+
+
+def _oauth_error_message(status_code: int | None, provider: str) -> str:
+    if status_code in (401, 403):
+        return (
+            f"{provider} OAuth authentication failed. Check /v1/scillm/auth, "
+            "refresh the provider login on the host, then retry."
+        )
+    if status_code == 404:
+        return (
+            f"{provider} reported that the requested model is unavailable. "
+            "Use /v1/scillm/models and request an exact supported model."
+        )
+    if status_code == 429:
+        return f"{provider} rate limited the OAuth call. Reduce concurrency; do not batch OAuth models."
+    return f"{provider} OAuth provider call failed. Inspect provider_error_code and details."
+
+
+def _extract_provider_error(error_text: str) -> tuple[str | None, str]:
+    try:
+        payload = json.loads(error_text)
+    except json.JSONDecodeError:
+        return None, error_text[:500]
+    if isinstance(payload, dict):
+        err = payload.get("error")
+        if isinstance(err, dict):
+            return str(err.get("type") or err.get("code") or "") or None, str(err.get("message") or payload)[:500]
+        if err:
+            return None, str(err)[:500]
+    return None, str(payload)[:500]
+
+
+def _apply_reasoning_effort(body: dict[str, Any], effort: str | None) -> tuple[bool, str | None, str | None]:
+    """Apply Claude thinking config for public reasoning effort values."""
+    if not effort or effort == "none":
+        return False, None, "none_requested" if effort == "none" else None
+    budget = _CLAUDE_THINKING_BUDGET_TOKENS.get(effort)
+    if budget is None:
+        return False, None, "unsupported_effort_for_provider"
+    body["thinking"] = {"type": "enabled", "budget_tokens": budget}
+    return True, "thinking.budget_tokens", None
+
+
+def _is_temperature_deprecated_error(status_code: int, error_text: str) -> bool:
+    lowered = error_text.lower()
+    return status_code == 400 and "temperature" in lowered and "deprecated" in lowered
+
+
+def _anthropic_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "anthropic-version": ANTHROPIC_VERSION,
+        "anthropic-beta": ANTHROPIC_BETA,
+        "user-agent": "claude-cli/2.1.75",
+        "x-app": "cli",
+        "content-type": "application/json",
+    }
 
 
 def _openai_tools_to_anthropic(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -275,10 +341,20 @@ async def claude_completion(
     """
     token = get_anthropic_token()
     if not token:
-        raise Exception("No Anthropic OAuth token available. Run Pi CLI /login first.")
+        raise ProviderOAuthError(
+            provider="anthropic-oauth",
+            status_code=401,
+            message="No Anthropic OAuth token available.",
+            provider_error_code="PROVIDER_AUTH_FAILED",
+            model_requested=model,
+            provider_auth_status="not_configured_or_expired",
+            project_agent_message="Run `claude auth login --claudeai`, then check /v1/scillm/auth before retrying.",
+        )
 
     # Map friendly names to API model IDs
     api_model = CLAUDE_MODEL_MAP.get(model, model)
+    reasoning_effort = kwargs.get("reasoning_effort")
+    require_exact_model = bool(kwargs.get("require_exact_model")) or kwargs.get("allow_model_remap") is False
 
     system_prompt, anthropic_msgs = _openai_to_anthropic_messages(messages)
 
@@ -303,6 +379,18 @@ async def claude_completion(
     if "stop" in kwargs:
         stop = kwargs["stop"]
         body["stop_sequences"] = stop if isinstance(stop, list) else [stop]
+    reasoning_forwarded, _, reasoning_ignored_reason = _apply_reasoning_effort(body, reasoning_effort)
+    if reasoning_effort and not reasoning_forwarded and reasoning_ignored_reason == "unsupported_effort_for_provider":
+        raise ProviderOAuthError(
+            provider="anthropic-oauth",
+            status_code=400,
+            message=f"Claude OAuth does not support reasoning_effort={reasoning_effort!r}.",
+            provider_error_code="PROVIDER_BAD_REQUEST",
+            model_requested=model,
+            provider_auth_status="configured",
+            provider_error_type="unsupported_reasoning_effort",
+            project_agent_message="Use one of: low, medium, high, xhigh, max; or omit reasoning_effort.",
+        )
 
     # Tool use: translate OpenAI tools format to Anthropic
     if "tools" in kwargs and kwargs["tools"]:
@@ -313,24 +401,32 @@ async def claude_completion(
             if tc is not None:
                 body["tool_choice"] = tc
 
-    # OAuth tokens use Authorization: Bearer, NOT x-api-key
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "anthropic-version": ANTHROPIC_VERSION,
-        "anthropic-beta": ANTHROPIC_BETA,
-        "user-agent": "claude-cli/2.1.75",
-        "x-app": "cli",
-        "content-type": "application/json",
-    }
+    headers = _anthropic_headers(token)
 
     logger.info("Claude OAuth call: model={}, {} messages, {} tools", model, len(anthropic_msgs), len(body.get("tools", [])))
 
     timeout = kwargs.get("timeout", 90)
     async with httpx.AsyncClient(timeout=float(timeout)) as client:
         resp = await client.post(ANTHROPIC_API_URL, json=body, headers=headers)
+        if resp.status_code in (401, 403):
+            refreshed_token = get_anthropic_token(force_refresh=True)
+            if refreshed_token:
+                logger.info("Retrying Claude OAuth call after forced token refresh")
+                headers = _anthropic_headers(refreshed_token)
+                resp = await client.post(
+                    ANTHROPIC_API_URL,
+                    json=body,
+                    headers=headers,
+                )
+        if "temperature" in body and _is_temperature_deprecated_error(resp.status_code, resp.text):
+            retry_body = dict(body)
+            retry_body.pop("temperature", None)
+            logger.info("Retrying Claude OAuth call without deprecated temperature parameter")
+            resp = await client.post(ANTHROPIC_API_URL, json=retry_body, headers=headers)
 
     if resp.status_code != 200:
         error_body = resp.text
+        provider_error_type, provider_message = _extract_provider_error(error_body)
         # Detect Anthropic OAuth gate changes — fail fast to cascade
         if "third-party" in error_body.lower() or "extra usage" in error_body.lower():
             logger.error(
@@ -339,10 +435,33 @@ async def claude_completion(
                 error_body[:300],
             )
         logger.warning("Claude API error {}: {}", resp.status_code, error_body[:500])
-        raise Exception(f"Claude API {resp.status_code}: {error_body[:500]}")
+        provider_error_code = provider_error_code_for_status(resp.status_code)
+        raise ProviderOAuthError(
+            provider="anthropic-oauth",
+            status_code=resp.status_code if resp.status_code in (400, 401, 403, 404, 429) else 502,
+            message=f"Claude API {resp.status_code}: {provider_message}",
+            provider_error_code=provider_error_code,
+            provider_status_code=resp.status_code,
+            model_requested=model,
+            provider_auth_status="provider_rejected" if resp.status_code in (401, 403) else "configured",
+            provider_error_type=provider_error_type,
+            project_agent_message=_oauth_error_message(resp.status_code, "Claude"),
+        )
 
     data = resp.json()
-    return _anthropic_to_openai_response(data, model)
+    completion = _anthropic_to_openai_response(data, model)
+    if require_exact_model and completion.model != api_model:
+        raise ProviderOAuthError(
+            provider="anthropic-oauth",
+            status_code=502,
+            message=f"Claude served model '{completion.model}' for requested model '{api_model}'.",
+            provider_error_code="PROVIDER_MODEL_MISMATCH",
+            model_requested=api_model,
+            model_served=completion.model,
+            provider_auth_status="configured",
+            project_agent_message="Requested and served Claude model differ; fail closed or choose an exact supported model.",
+        )
+    return completion
 
 
 async def claude_completion_stream(
@@ -357,9 +476,22 @@ async def claude_completion_stream(
     """
     token = get_anthropic_token()
     if not token:
-        raise Exception("No Anthropic OAuth token available.")
+        err = sse_format({"error": {
+            "message": "No Anthropic OAuth token available.",
+            "type": "provider_auth_error",
+            "provider_error_code": "PROVIDER_AUTH_FAILED",
+            "provider": "anthropic-oauth",
+            "model_requested": model,
+            "provider_auth_status": "not_configured_or_expired",
+            "project_agent_message": "Run `claude auth login --claudeai`, then check /v1/scillm/auth before retrying.",
+        }})
+        yield err.encode()
+        yield sse_done().encode()
+        return
 
     api_model = CLAUDE_MODEL_MAP.get(model, model)
+    reasoning_effort = kwargs.get("reasoning_effort")
+    require_exact_model = bool(kwargs.get("require_exact_model")) or kwargs.get("allow_model_remap") is False
     system_prompt, anthropic_msgs = _openai_to_anthropic_messages(messages)
 
     system_blocks: list[dict[str, str]] = [
@@ -382,6 +514,21 @@ async def claude_completion_stream(
     if "stop" in kwargs:
         stop = kwargs["stop"]
         body["stop_sequences"] = stop if isinstance(stop, list) else [stop]
+    reasoning_forwarded, _, reasoning_ignored_reason = _apply_reasoning_effort(body, reasoning_effort)
+    if reasoning_effort and not reasoning_forwarded and reasoning_ignored_reason == "unsupported_effort_for_provider":
+        err = sse_format({"error": {
+            "message": f"Claude OAuth does not support reasoning_effort={reasoning_effort!r}.",
+            "type": "provider_error",
+            "provider_error_code": "PROVIDER_BAD_REQUEST",
+            "provider": "anthropic-oauth",
+            "model_requested": model,
+            "provider_auth_status": "configured",
+            "provider_error_type": "unsupported_reasoning_effort",
+            "project_agent_message": "Use one of: low, medium, high, xhigh, max; or omit reasoning_effort.",
+        }})
+        yield err.encode()
+        yield sse_done().encode()
+        return
 
     # Tool use: translate OpenAI tools format to Anthropic
     if "tools" in kwargs and kwargs["tools"]:
@@ -392,14 +539,7 @@ async def claude_completion_stream(
             if tc is not None:
                 body["tool_choice"] = tc
 
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "anthropic-version": ANTHROPIC_VERSION,
-        "anthropic-beta": ANTHROPIC_BETA,
-        "user-agent": "claude-cli/2.1.75",
-        "x-app": "cli",
-        "content-type": "application/json",
-    }
+    headers = _anthropic_headers(token)
 
     logger.info("Claude OAuth stream: model={}, {} messages, {} tools", model, len(anthropic_msgs), len(body.get("tools", [])))
     chunk_id = make_chunk_id()
@@ -412,8 +552,19 @@ async def claude_completion_stream(
                 if resp.status_code != 200:
                     error_body = await resp.aread()
                     error_text = error_body.decode("utf-8", errors="replace")
+                    provider_error_type, provider_message = _extract_provider_error(error_text)
                     logger.warning("Claude stream error {}: {}", resp.status_code, error_text[:500])
-                    err = sse_format({"error": {"message": f"Claude API {resp.status_code}: {error_text[:300]}", "type": "provider_error"}})
+                    provider_error_code = provider_error_code_for_status(resp.status_code)
+                    err = sse_format({"error": {
+                        "message": f"Claude API {resp.status_code}: {provider_message[:300]}",
+                        "type": "provider_auth_error" if provider_error_code == "PROVIDER_AUTH_FAILED" else "provider_error",
+                        "provider_error_code": provider_error_code,
+                        "provider_status_code": resp.status_code,
+                        "provider": "anthropic-oauth",
+                        "provider_error_type": provider_error_type,
+                        "model_requested": model,
+                        "project_agent_message": _oauth_error_message(resp.status_code, "Claude"),
+                    }})
                     yield err.encode()
                     yield sse_done().encode()
                     return
@@ -474,6 +625,20 @@ async def claude_completion_stream(
 
                         elif event_type == "message_delta":
                             delta = data.get("delta", {})
+                            actual_model = data.get("message", {}).get("model") or api_model
+                            if require_exact_model and actual_model != api_model:
+                                err = sse_format({"error": {
+                                    "message": f"Claude served model '{actual_model}' for requested model '{api_model}'.",
+                                    "type": "provider_error",
+                                    "provider_error_code": "PROVIDER_MODEL_MISMATCH",
+                                    "provider": "anthropic-oauth",
+                                    "model_requested": api_model,
+                                    "model_served": actual_model,
+                                    "project_agent_message": "Requested and served Claude model differ; fail closed.",
+                                }})
+                                yield err.encode()
+                                yield sse_done().encode()
+                                return
                             stop_reason = delta.get("stop_reason", "end_turn")
                             if stop_reason == "max_tokens":
                                 finish = "length"

--- a/src/scillm/proxy/providers/claude.py
+++ b/src/scillm/proxy/providers/claude.py
@@ -31,10 +31,15 @@ CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for C
 
 # Map friendly model names to Anthropic API model IDs
 CLAUDE_MODEL_MAP = {
-    "claude-sonnet-4-6": "claude-sonnet-4-20250514",
-    "claude-opus-4-6": "claude-opus-4-20250514",
+    "claude-sonnet-5": "claude-sonnet-5",
+    "claude-fable-5": "claude-fable-5",
+    "claude-sonnet-4-6": "claude-sonnet-4-6",
+    "claude-opus-4-8": "claude-opus-4-8",
+    "claude-opus-4-7": "claude-opus-4-7",
+    "claude-opus-4-6": "claude-opus-4-6",
+    "claude-opus-4-5": "claude-opus-4-5-20251101",
     "claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    "claude-sonnet-4-5": "claude-sonnet-4-5-20250514",
+    "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
 }
 
 

--- a/tests/test_caller_policy.py
+++ b/tests/test_caller_policy.py
@@ -4,6 +4,19 @@ import httpx
 import pytest
 
 from chutes.middleware.caller_policy import CallerPolicyMiddleware, policy_target_model, request_capabilities
+
+
+def test_example_profile_routes_evidence_case_to_gemini_only() -> None:
+    from pathlib import Path
+
+    import yaml
+
+    profile_path = Path(__file__).parents[1] / "registry" / "caller_profiles.example.yaml"
+    profile = yaml.safe_load(profile_path.read_text())["caller_profiles"]["create-evidence-case"]
+
+    assert profile["allowed_models"] == ["gemini-flash"]
+    assert "qra-*" in profile["deny_model_patterns"]
+    assert profile["allow_streaming"] is False
 from scillm.proxy.config import CallerProfile, Deployment, GeneralSettings, ModelGroup, ProxyConfig, load_config
 from scillm.proxy.middleware import MiddlewareReject
 from scillm.proxy import app as proxy_app
@@ -12,7 +25,7 @@ from scillm.proxy import app as proxy_app
 def _request(
     *,
     caller: str = "create-qras",
-    model: str = "text",
+    model: str = "qra-deepseek-pool",
     messages: object | None = None,
     metadata: dict | None = None,
     **extra,
@@ -32,7 +45,7 @@ def _policy_config() -> ProxyConfig:
     return ProxyConfig(
         caller_profiles={
             "create-qras": CallerProfile(
-                allowed_models=["qra-deepseek-pool", "text"],
+                allowed_models=["qra-deepseek-pool"],
                 deny_model_patterns=["gpt-*", "claude-*", "vlm-*"],
                 require_scillm_metadata=["batch_id", "item_id"],
                 allow_tools=False,
@@ -43,7 +56,7 @@ def _policy_config() -> ProxyConfig:
                 max_timeout_s=60,
             ),
             "pdf-extraction-review": CallerProfile(
-                allowed_models=["vlm", "text-gemini"],
+                allowed_models=["vlm", "gemini-flash"],
                 allow_tools=False,
                 allow_images=True,
                 allow_pdfs=True,
@@ -111,7 +124,7 @@ async def test_profile_rejects_tools_and_files():
     }]
     with pytest.raises(MiddlewareReject) as image_exc:
         await file_middleware.pre_call(
-            _request(caller="no-files", messages=image_messages)
+            _request(caller="no-files", model="vlm", messages=image_messages)
         )
     assert "files are not allowed" in image_exc.value.message
 
@@ -154,7 +167,7 @@ async def test_deny_patterns_apply_to_fallback_chain():
 
 def test_multimodal_text_request_policy_target_is_vlm():
     request = _request(
-        model="text",
+        model="vlm",
         messages=[{
             "role": "user",
             "content": [
@@ -173,13 +186,13 @@ def test_config_loads_caller_profiles(tmp_path):
     config_path.write_text(
         """
 model_list:
-  - model_name: text
+  - model_name: qra-deepseek-pool
     scillm_params:
-      model: deepseek-ai/DeepSeek-V3.2-TEE
+      model: Qwen/Qwen3.6-27B-TEE
       api_base: https://llm.chutes.ai/v1
 caller_profiles:
   create-qras:
-    allowed_models: [qra-deepseek-pool, text]
+    allowed_models: [qra-deepseek-pool]
     require_scillm_metadata: [batch_id, item_id]
     allow_tools: "false"
     allow_files: false
@@ -204,12 +217,12 @@ async def test_capabilities_endpoint_reports_profiles_and_adapters(monkeypatch: 
         ProxyConfig(
             general=GeneralSettings(master_key=""),
             model_groups={
-                "text": ModelGroup(
-                    name="text",
-                    deployments=[Deployment(model="deepseek-ai/DeepSeek-V3.2-TEE", api_base="https://llm.chutes.ai/v1")],
+                "Qwen/Qwen3.6-27B-TEE": ModelGroup(
+                    name="Qwen/Qwen3.6-27B-TEE",
+                    deployments=[Deployment(model="Qwen/Qwen3.6-27B-TEE", api_base="https://llm.chutes.ai/v1")],
                 )
             },
-            caller_profiles={"worker": CallerProfile(allowed_models=["text"], allow_tools=False)},
+            caller_profiles={"worker": CallerProfile(allowed_models=["Qwen/Qwen3.6-27B-TEE"], allow_tools=False)},
         ),
     )
 
@@ -220,6 +233,36 @@ async def test_capabilities_endpoint_reports_profiles_and_adapters(monkeypatch: 
     assert response.status_code == 200
     data = response.json()
     assert data["version"] == 1
-    assert "text" in data["model_groups"]
+    assert "Qwen/Qwen3.6-27B-TEE" in data["model_groups"]
     assert "opencode_go" in data["adapters"]
     assert data["caller_profiles"]["worker"]["allow_tools"] is False
+
+
+def test_chutes_config_inventory_reports_stale_provider_models(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        proxy_app,
+        "_config",
+        ProxyConfig(
+            general=GeneralSettings(master_key=""),
+            model_groups={
+                "deepseek-ai/DeepSeek-V3.2-TEE": ModelGroup(
+                    name="deepseek-ai/DeepSeek-V3.2-TEE",
+                    deployments=[Deployment(model="deepseek-ai/DeepSeek-V3.2-TEE", api_base="https://llm.chutes.ai/v1")],
+                ),
+                "deepseek-ai/DeepSeek-V3.1-TEE": ModelGroup(
+                    name="deepseek-ai/DeepSeek-V3.1-TEE",
+                    deployments=[Deployment(model="deepseek-ai/DeepSeek-V3.1-TEE", api_base="https://llm.chutes.ai/v1")],
+                ),
+            },
+            fallbacks={"deepseek-ai/DeepSeek-V3.2-TEE": ["deepseek-ai/DeepSeek-V3.1-TEE"]},
+            aliases={},
+        ),
+    )
+
+    inventory = proxy_app._chutes_config_inventory(["deepseek-ai/DeepSeek-V3.2-TEE"])
+
+    assert inventory["status"] == "config_drift"
+    assert inventory["configured_available_models"] == ["deepseek-ai/DeepSeek-V3.2-TEE"]
+    assert inventory["configured_unavailable_models"] == ["deepseek-ai/DeepSeek-V3.1-TEE"]
+    assert inventory["unavailable_fallback_targets"] == ["deepseek-ai/DeepSeek-V3.1-TEE"]
+    assert inventory["alias_resolutions"] == {}

--- a/tests/test_caller_policy.py
+++ b/tests/test_caller_policy.py
@@ -6,7 +6,7 @@ import pytest
 from chutes.middleware.caller_policy import CallerPolicyMiddleware, policy_target_model, request_capabilities
 
 
-def test_example_profile_routes_evidence_case_to_gemini_only() -> None:
+def test_example_profile_limits_evidence_case_to_approved_live_lanes() -> None:
     from pathlib import Path
 
     import yaml
@@ -14,7 +14,10 @@ def test_example_profile_routes_evidence_case_to_gemini_only() -> None:
     profile_path = Path(__file__).parents[1] / "registry" / "caller_profiles.example.yaml"
     profile = yaml.safe_load(profile_path.read_text())["caller_profiles"]["create-evidence-case"]
 
-    assert profile["allowed_models"] == ["gemini-flash"]
+    assert profile["allowed_models"] == [
+        "gemini-flash",
+        "deepseek-ai/DeepSeek-V3.2-TEE",
+    ]
     assert "qra-*" in profile["deny_model_patterns"]
     assert profile["allow_streaming"] is False
 from scillm.proxy.config import CallerProfile, Deployment, GeneralSettings, ModelGroup, ProxyConfig, load_config

--- a/tests/test_claude_model_aliases.py
+++ b/tests/test_claude_model_aliases.py
@@ -1,0 +1,13 @@
+from scillm.proxy.providers.claude import CLAUDE_MODEL_MAP
+
+
+def test_claude_model_aliases_use_live_oauth_ids():
+    assert CLAUDE_MODEL_MAP["claude-sonnet-5"] == "claude-sonnet-5"
+    assert CLAUDE_MODEL_MAP["claude-fable-5"] == "claude-fable-5"
+    assert CLAUDE_MODEL_MAP["claude-sonnet-4-6"] == "claude-sonnet-4-6"
+    assert CLAUDE_MODEL_MAP["claude-opus-4-8"] == "claude-opus-4-8"
+    assert CLAUDE_MODEL_MAP["claude-opus-4-7"] == "claude-opus-4-7"
+    assert CLAUDE_MODEL_MAP["claude-opus-4-6"] == "claude-opus-4-6"
+    assert CLAUDE_MODEL_MAP["claude-opus-4-5"] == "claude-opus-4-5-20251101"
+    assert CLAUDE_MODEL_MAP["claude-haiku-4-5"] == "claude-haiku-4-5-20251001"
+    assert CLAUDE_MODEL_MAP["claude-sonnet-4-5"] == "claude-sonnet-4-5-20250929"

--- a/tests/test_generate_image_script.py
+++ b/tests/test_generate_image_script.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.generate_image import (
+    PROMPT_MAX_CHARS,
+    _default_timeout_s,
+    _load_prompt,
+    generate_image_codex_oauth,
+    generate_image_openai_api,
+)
+
+
+def test_load_prompt_rejects_empty(tmp_path: Path) -> None:
+    path = tmp_path / "empty.md"
+    path.write_text("   \n", encoding="utf-8")
+    with pytest.raises(ValueError, match="empty"):
+        _load_prompt(path)
+
+
+def test_load_prompt_rejects_too_long(tmp_path: Path) -> None:
+    path = tmp_path / "big.md"
+    path.write_text("x" * (PROMPT_MAX_CHARS + 1), encoding="utf-8")
+    with pytest.raises(ValueError, match="exceeds"):
+        _load_prompt(path)
+
+
+def test_generate_image_openai_api_writes_png_and_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("A red circle on white", encoding="utf-8")
+    out = tmp_path / "out" / "circle.png"
+    png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x10\x00\x00\x00\x10\x08\x02\x00\x00\x00\x90\x91h6\x00\x00\x00\x00IEND\xaeB`\x82"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/images/generations"
+        assert request.headers["x-caller-skill"] == "test-skill"
+        body = json.loads(request.content.decode())
+        assert body["model"] == "gpt-image-2"
+        assert body["quality"] == "high"
+        return httpx.Response(
+            200,
+            json={
+                "created": 1,
+                "object": "list",
+                "model": "gpt-image-2",
+                "provider": "openai",
+                "data": [{"b64_json": base64.b64encode(png).decode("ascii")}],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def fake_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        kwargs["base_url"] = "http://test"
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", fake_client)
+
+    receipt = generate_image_openai_api(
+        prompt_file=prompt_file,
+        out=out,
+        base_url="http://test",
+        master_key="test-key",
+        caller_skill="test-skill",
+    )
+
+    assert out.is_file()
+    assert receipt["auth"] == "openai-api-key"
+    assert receipt["width"] == 16
+    assert receipt["height"] == 16
+
+
+def test_codex_oauth_streams_events_out_before_process_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("A blue square on white", encoding="utf-8")
+    out = tmp_path / "image.png"
+    receipt_path = tmp_path / "image_receipt.json"
+    events_out = tmp_path / "events.jsonl"
+    png = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x10\x00\x00\x00\x10\x08\x02\x00\x00\x00"
+        b"\x90\x91h6\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    png_sha = hashlib.sha256(png).hexdigest()
+    events = [
+        {"type": "thread.started", "thread_id": "thread-live"},
+        {"type": "item.completed", "item": {"type": "image_generation"}},
+    ]
+
+    class FakeProc:
+        def __init__(self, *args, **kwargs) -> None:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(png)
+            receipt_path.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "auth": "codex-oauth",
+                        "path": str(out),
+                        "width": 16,
+                        "height": 16,
+                        "sha256": png_sha,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            read_fd, write_fd = os.pipe()
+            with os.fdopen(write_fd, "w", encoding="utf-8") as writer:
+                for event in events:
+                    writer.write(json.dumps(event) + "\n")
+            self.stdout = os.fdopen(read_fd, "r", encoding="utf-8")
+            self.stderr = io.StringIO("")
+
+        def wait(self, timeout: float | None = None) -> int:
+            persisted = [
+                json.loads(line)
+                for line in events_out.read_text(encoding="utf-8").splitlines()
+            ]
+            assert persisted == events
+            return 0
+
+        def terminate(self) -> None:
+            pass
+
+        def kill(self) -> None:
+            pass
+
+    monkeypatch.setattr("scripts.generate_image._codex_oauth_available", lambda: True)
+    monkeypatch.setattr("subprocess.Popen", FakeProc)
+
+    receipt = generate_image_codex_oauth(
+        prompt_file=prompt_file,
+        out=out,
+        cwd=tmp_path,
+        receipt_path=receipt_path,
+        timeout_s=45.0,
+        first_event_s=5.0,
+        events_out=events_out,
+    )
+
+    assert receipt["auth"] == "codex-oauth"
+    persisted = [json.loads(line) for line in events_out.read_text(encoding="utf-8").splitlines()]
+    assert persisted == events
+
+
+def test_default_timeout_s_uses_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCILLM_IMAGE_TIMEOUT_S", "1234")
+
+    assert _default_timeout_s() == 1234.0

--- a/tests/test_oauth_error_handling.py
+++ b/tests/test_oauth_error_handling.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from scillm.proxy import app as proxy_app
+from scillm.proxy.errors import ProviderOAuthError
+from scillm.proxy.providers import claude, codex
+
+
+@pytest.mark.asyncio
+async def test_codex_missing_oauth_token_is_structured(monkeypatch):
+    monkeypatch.setattr(codex, "get_codex_credentials", lambda *a, **k: None)
+
+    with pytest.raises(ProviderOAuthError) as exc_info:
+        await codex.codex_completion("gpt-5.5", [{"role": "user", "content": "hi"}])
+
+    err = exc_info.value.to_dict()["error"]
+    assert err["type"] == "provider_auth_error"
+    assert err["details"]["provider"] == "codex-oauth"
+    assert err["details"]["provider_error_code"] == "PROVIDER_AUTH_FAILED"
+    assert err["details"]["model_requested"] == "gpt-5.5"
+    assert "codex login" in err["details"]["project_agent_message"]
+
+
+@pytest.mark.asyncio
+async def test_codex_forced_refresh_failure_raises_structured_oauth_error(monkeypatch):
+    calls: list[bool] = []
+
+    def fake_credentials(*, force_refresh: bool = False):
+        calls.append(force_refresh)
+        if force_refresh:
+            return None
+        return ("stale-access-token", "acct")
+
+    class FakeStream:
+        status_code = 401
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aread(self):
+            return b'{"error":{"code":"token_revoked","message":"Encountered invalidated oauth token"}}'
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return FakeStream()
+
+    monkeypatch.setattr(codex, "get_codex_credentials", fake_credentials)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    with pytest.raises(ProviderOAuthError) as exc_info:
+        await codex.codex_completion("gpt-5.5", [{"role": "user", "content": "hi"}])
+
+    err = exc_info.value.to_dict()["error"]
+    assert calls == [False, True, True]
+    assert err["type"] == "provider_auth_error"
+    assert err["details"]["provider"] == "codex-oauth"
+    assert err["details"]["provider_error_code"] == "PROVIDER_AUTH_FAILED"
+    assert err["details"]["provider_auth_status"] == "not_configured_or_expired"
+    assert "codex login" in err["details"]["project_agent_message"]
+
+
+@pytest.mark.asyncio
+async def test_claude_missing_oauth_token_is_structured(monkeypatch):
+    monkeypatch.setattr(claude, "get_anthropic_token", lambda: None)
+
+    with pytest.raises(ProviderOAuthError) as exc_info:
+        await claude.claude_completion("claude-sonnet-4-20250514", [{"role": "user", "content": "hi"}])
+
+    err = exc_info.value.to_dict()["error"]
+    assert err["type"] == "provider_auth_error"
+    assert err["details"]["provider"] == "anthropic-oauth"
+    assert err["details"]["provider_error_code"] == "PROVIDER_AUTH_FAILED"
+    assert err["details"]["model_requested"] == "claude-sonnet-4-20250514"
+    assert "claude auth login" in err["details"]["project_agent_message"]
+
+
+@pytest.mark.asyncio
+async def test_claude_forced_refresh_retries_revoked_access_token(monkeypatch):
+    token_calls: list[bool] = []
+    auth_headers: list[str] = []
+
+    def fake_token(*, force_refresh: bool = False):
+        token_calls.append(force_refresh)
+        return "fresh-access-token" if force_refresh else "stale-access-token"
+
+    class FakeResponse:
+        def __init__(self, status_code: int, text: str, payload: dict | None = None):
+            self.status_code = status_code
+            self.text = text
+            self._payload = payload or {}
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, _url, *, json, headers):
+            auth_headers.append(headers["Authorization"])
+            if len(auth_headers) == 1:
+                return FakeResponse(
+                    401,
+                    '{"error":{"type":"authentication_error","message":"OAuth access token has been revoked"}}',
+                )
+            return FakeResponse(
+                200,
+                "{}",
+                {
+                    "model": "claude-sonnet-4-6",
+                    "content": [{"type": "text", "text": "OK"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            )
+
+    monkeypatch.setattr(claude, "get_anthropic_token", fake_token)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    result = await claude.claude_completion(
+        "claude-sonnet-4-6",
+        [{"role": "user", "content": "Return exactly OK."}],
+    )
+
+    assert token_calls == [False, True]
+    assert auth_headers == ["Bearer stale-access-token", "Bearer fresh-access-token"]
+    assert result.choices[0].message.content == "OK"
+
+
+@pytest.mark.asyncio
+async def test_claude_retries_without_deprecated_temperature(monkeypatch):
+    request_bodies: list[dict] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int, text: str, payload: dict | None = None):
+            self.status_code = status_code
+            self.text = text
+            self._payload = payload or {}
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, _url, *, json, headers):
+            request_bodies.append(dict(json))
+            if len(request_bodies) == 1:
+                return FakeResponse(
+                    400,
+                    '{"error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."}}',
+                )
+            return FakeResponse(
+                200,
+                "{}",
+                {
+                    "model": "claude-opus-4-8",
+                    "content": [{"type": "text", "text": "OK"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            )
+
+    monkeypatch.setattr(claude, "get_anthropic_token", lambda **_kwargs: "access-token")
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    result = await claude.claude_completion(
+        "claude-opus-4-8",
+        [{"role": "user", "content": "Return exactly OK."}],
+        temperature=0,
+    )
+
+    assert request_bodies[0]["temperature"] == 0
+    assert "temperature" not in request_bodies[1]
+    assert result.choices[0].message.content == "OK"
+
+
+def test_scillm_reasoning_and_multimodal_proof_for_gpt55():
+    body = {
+        "model": "gpt-5.5",
+        "reasoning_effort": "high",
+    }
+    response = {
+        "model": "gpt-5.5",
+        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+    }
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "inspect"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ],
+    }]
+
+    proxy_app._attach_proof_fields(body, response, messages)
+
+    assert response["scillm_reasoning"] == {
+        "requested_effort": "high",
+        "applied_effort": "high",
+        "forwarded": True,
+        "provider_field": "reasoning.effort",
+        "ignored_reason": None,
+    }
+    assert response["scillm_multimodal"]["input_multimodal"] is True
+    assert response["scillm_multimodal"]["image_count"] == 1
+    assert response["scillm_multimodal"]["image_seen_by"] == "codex-oauth"
+
+
+def test_provider_oauth_error_exposes_model_mismatch_details():
+    exc = ProviderOAuthError(
+        provider="codex-oauth",
+        status_code=502,
+        message="Codex served model 'gpt-5.4' for requested model 'gpt-5.3-codex'.",
+        provider_error_code="PROVIDER_MODEL_MISMATCH",
+        model_requested="gpt-5.3-codex",
+        model_served="gpt-5.4",
+        provider_auth_status="configured",
+        project_agent_message="Requested and served model differ.",
+    )
+
+    err = exc.to_dict()["error"]
+    assert err["type"] == "provider_error"
+    assert err["details"]["provider_error_code"] == "PROVIDER_MODEL_MISMATCH"
+    assert err["details"]["model_requested"] == "gpt-5.3-codex"
+    assert err["details"]["model_served"] == "gpt-5.4"


### PR DESCRIPTION
## Scope

This branch contains existing SciLLM runtime work plus the latest Claude OAuth recovery patch at commit `a640bd1bd2`.

Latest repair in `a640bd1bd2`:

- `get_anthropic_token(force_refresh=True)` refreshes Anthropic OAuth after provider 401/403.
- Refreshed Claude credentials are cached in-process when the mounted Claude Code credentials file is read-only.
- Claude non-streaming calls retry once after forced refresh.
- Claude non-streaming calls retry once without `temperature` when Anthropic rejects `temperature` as deprecated for models such as `claude-opus-4-8`.
- Adds focused OAuth regression tests.

## Proof

Focused checks from `/home/graham/workspace/experiments/scillm`:

- `PYTHONPATH=.:src UV_PROJECT_ENVIRONMENT=/tmp/scillm-venv-auth-refresh-20260729T1956Z uv run pytest -q tests/test_oauth_error_handling.py` => `7 passed, 1 warning`.
- `UV_PROJECT_ENVIRONMENT=/tmp/scillm-venv-auth-refresh-20260729T1956Z uv run ruff check --select F,E9 src/scillm/proxy/providers/auth.py src/scillm/proxy/providers/claude.py tests/test_oauth_error_handling.py` => pass.
- `UV_PROJECT_ENVIRONMENT=/tmp/scillm-venv-auth-refresh-20260729T1956Z uv run python -m py_compile src/scillm/proxy/providers/auth.py src/scillm/proxy/providers/claude.py tests/test_oauth_error_handling.py` => pass.
- `git diff --check -- src/scillm/proxy/providers/auth.py src/scillm/proxy/providers/claude.py tests/test_oauth_error_handling.py` => pass.

Live local provider proofs after restarting `docker-scillm-proxy-1`:

- `/tmp/scillm-claude-opus48-temp-live-proof-20260729T2003Z.json`: `status=PASS`, `mocked=false`, `live=true`, `provider_live=true`, request model `claude-opus-4-8`, caller sent `temperature: 0`, response HTTP 200 with content `OK`.
- `/tmp/scillm-claude-crosscheck-20260729T2002Z.json`: `status=PASS` for `claude-sonnet-4-6`, `claude-opus-4-8`, and `claude-opus-4-6`.

## Review note

The branch is broad because it was already ahead of main before this repair. Reviewers should isolate the latest commit `a640bd1bd2` for the Claude recovery behavior if they do not want to review the whole branch at once.
